### PR TITLE
fix: enable referencing const values for the builder

### DIFF
--- a/test/fixtures/dart_reference/lib/main.dart
+++ b/test/fixtures/dart_reference/lib/main.dart
@@ -676,7 +676,7 @@ void main(List<String> args) async {
 
     // Custom invoker list
     firebase.https.onRequest(
-      name: 'httpsCustomInvoker',
+      name: _OptionsSilly.httpsCustomInvoker,
       options: const HttpsOptions(
         invoker: Invoker(['user1@example.com', 'user2@example.com']),
       ),
@@ -685,7 +685,7 @@ void main(List<String> args) async {
 
     // Pub/Sub with options
     firebase.pubsub.onMessagePublished(
-      topic: 'options-topic',
+      topic: optionsTopic,
       options: const PubSubOptions(
         memory: Memory(MemoryOption.mb256),
         timeoutSeconds: TimeoutSeconds(120),
@@ -698,6 +698,14 @@ void main(List<String> args) async {
 
     print('Functions registered successfully!');
   });
+}
+
+/// Testing constant expression evaluation
+const optionsTopic = 'options-topic';
+
+class _OptionsSilly {
+  /// Testing constant expression evaluation
+  static const httpsCustomInvoker = 'httpsCustomInvoker';
 }
 
 // =============================================================================

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -2,7 +2,6 @@
 ///
 /// This test ensures that the Dart builder generates manifests compatible
 /// with the Node.js Firebase Functions SDK.
-@Tags(['snapshot'])
 library;
 
 import 'dart:convert';


### PR DESCRIPTION
This is nice if folks want to share endpoints with client apps, for instance
