### PR TITLE
docs(alerts): add Billing onPlanAutomatedUpdatePublished to README and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,16 @@ firebase.alerts.billing.onPlanUpdatePublished(
   },
 );
 
+// Billing automated plan updates
+firebase.alerts.billing.onPlanAutomatedUpdatePublished(
+  (event) async {
+    final payload = event.data?.payload;
+    print('Automated plan update:');
+    print('  Plan: ${payload?.billingPlan}');
+    print('  Type: ${payload?.notificationType}');
+  },
+);
+
 // Performance threshold alerts
 firebase.alerts.performance.onThresholdAlertPublished(
   options: const AlertOptions(appId: '1:123456789:ios:abcdef'),

--- a/example/alerts/bin/server.dart
+++ b/example/alerts/bin/server.dart
@@ -21,6 +21,14 @@ void main(List<String> args) async {
       print('  Type: ${payload?.notificationType}');
     });
 
+    // Billing automated plan update alert
+    firebase.alerts.billing.onPlanAutomatedUpdatePublished((event) async {
+      final payload = event.data?.payload;
+      print('Billing automated plan update:');
+      print('  Plan: ${payload?.billingPlan}');
+      print('  Type: ${payload?.notificationType}');
+    });
+
     // Performance threshold alert with app ID filter
     firebase.alerts.performance.onThresholdAlertPublished(
       options: const AlertOptions(appId: '1:123456789:ios:abcdef'),


### PR DESCRIPTION
Closes #65

- README: add `onPlanAutomatedUpdatePublished` sample in Firebase Alerts section
- example/alerts: add `onPlanAutomatedUpdatePublished` handler sample