### PR TITLE
docs(alerts): add Crashlytics onVelocityAlertPublished to README and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,17 @@ firebase.alerts.crashlytics.onNewFatalIssuePublished(
   },
 );
 
+// Crashlytics velocity alerts
+firebase.alerts.crashlytics.onVelocityAlertPublished(
+  (event) async {
+    final payload = event.data?.payload;
+    print('Velocity alert: ${payload?.issue.title}');
+    print('Crash count: ${payload?.crashCount}');
+    print('Percentage: ${payload?.crashPercentage}%');
+    print('First version: ${payload?.firstVersion}');
+  },
+);
+
 // Billing plan updates
 firebase.alerts.billing.onPlanUpdatePublished(
   (event) async {

--- a/example/alerts/bin/server.dart
+++ b/example/alerts/bin/server.dart
@@ -12,6 +12,16 @@ void main(List<String> args) async {
       print('  App ID: ${event.appId}');
     });
 
+    // Crashlytics velocity alert
+    firebase.alerts.crashlytics.onVelocityAlertPublished((event) async {
+      final payload = event.data?.payload;
+      print('Crashlytics velocity alert:');
+      print('  Issue: ${payload?.issue.title}');
+      print('  Crash count: ${payload?.crashCount}');
+      print('  Percentage: ${payload?.crashPercentage}%');
+      print('  First version: ${payload?.firstVersion}');
+    });
+
     // Billing plan update alert
     firebase.alerts.billing.onPlanUpdatePublished((event) async {
       final payload = event.data?.payload;


### PR DESCRIPTION
Closes #71

- README: add `onVelocityAlertPublished` sample in Firebase Alerts section
- example/alerts: add `onVelocityAlertPublished` handler sample