### PR TITLE
fix(ci): use google_cloud_storage from pub.dev, remove googleapis_storage override

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   analyzer: ^10.0.1
   glob: ^2.1.3
   yaml_edit: ^2.2.3
+  google_cloud_storage: ^0.5.1
 
 dev_dependencies:
   build_runner: ^2.10.5
@@ -62,8 +63,3 @@ dependency_overrides:
       url: https://github.com/invertase/dart_firebase_admin.git
       ref: next
       path: packages/google_cloud_firestore
-  googleapis_storage:
-    git:
-      url: https://github.com/invertase/dart_firebase_admin.git
-      ref: next
-      path: packages/googleapis_storage


### PR DESCRIPTION
## Summary

- **Add** `google_cloud_storage: ^0.5.1` from [pub.dev](https://pub.dev/packages/google_cloud_storage).
- **Remove** the `dependency_overrides` entry for `googleapis_storage` (git path in `dart_firebase_admin`).

This allows CI to rely on the published package instead of the in-repo `googleapis_storage` path. `dart_firebase_admin@next` has already been updated to use `google_cloud_storage` ([invertase/dart_firebase_admin#182](https://github.com/invertase/dart_firebase_admin/pull/182)), so resolution succeeds with `ref: next`.

## Verification

- `dart pub get` resolves successfully.
- `dart test test/unit/storage_test.dart` passes.