### PR TITLE
Fix _baseImageUriSuffix

### DIFF
--- a/lib/src/builder/manifest.dart
+++ b/lib/src/builder/manifest.dart
@@ -128,9 +128,11 @@ List<Map<String, String>> _buildRequiredAPIs(
 }
 
 /// The base image URI template for Cloud Run deployment.
+///
 /// The region prefix is substituted at generation time.
+/// See: https://cloud.google.com/run/docs/runtime-support#support_schedule
 const _baseImageUriSuffix =
-    '-docker.pkg.dev/serverless-runtimes/google-24/osonly24';
+    '-docker.pkg.dev/serverless-runtimes/google-24/runtimes/osonly24';
 
 /// Builds a single endpoint entry as a map.
 Map<String, dynamic> _buildEndpointMap(EndpointSpec endpoint) {


### PR DESCRIPTION
before this fix, I hit this error

```
[debug] [2026-03-26T20:38:48.115Z] Failed to check artifact cleanup policy for region us-central1:Request to https://artifactregistry.googleapis.com/v1/projects/j832-com/locations/us-central1/repositories/gcf-artifacts had HTTP Error: 404, Requested entity was not found. {"name":"FirebaseError","children":[],"context":{"body":{"error":{"code":404,"message":"Requested entity was not found.","status":"NOT_FOUND"}},"response":{"statusCode":404}},"exit":1,"message":"Request to https://artifactregistry.googleapis.com/v1/projects/j832-com/locations/us-central1/repositories/gcf-artifacts had HTTP Error: 404, Requested entity was not found.","status":404}
```
