### PR TITLE
Refactor Firebase app initialization to fail fast and remove nullable fields

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -50,4 +50,8 @@
 library;
 
 export 'src/logger/logger.dart'
-    hide createLogger, projectIdZoneKey, traceIdZoneKey;
+    hide
+        createLogger,
+        projectIdZoneKey,
+        traceIdZoneKey,
+        cloudTraceContextHeader;

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -27,7 +27,6 @@ import 'eventarc/eventarc_namespace.dart';
 import 'firestore/firestore_namespace.dart';
 import 'https/https_namespace.dart';
 import 'identity/identity_namespace.dart';
-import 'logger/logger.dart';
 import 'pubsub/pubsub_namespace.dart';
 import 'remote_config/remote_config_namespace.dart';
 import 'scheduler/scheduler_namespace.dart';
@@ -39,45 +38,42 @@ import 'test_lab/test_lab_namespace.dart';
 ///
 /// Provides access to all function namespaces (https, pubsub, firestore, etc.).
 class Firebase {
-  Firebase() : _env = FirebaseEnv() {
-    _initializeAdminSDK();
+  factory Firebase() {
+    final env = FirebaseEnv();
+
+    // Initialize Admin SDK
+    final adminApp = FirebaseApp.initializeApp(
+      options: AppOptions(
+        credential: Credential.fromApplicationDefaultCredentials(),
+        projectId: env.projectId,
+      ),
+    );
+
+    return Firebase._(
+      adminApp: adminApp,
+      firestoreAdmin: adminApp.firestore(),
+      env: env,
+    );
   }
 
-  FirebaseApp? _adminApp;
-  gfs.Firestore? _firestoreInstance;
-
-  /// Initialize the Firebase Admin SDK
-  void _initializeAdminSDK() {
-    if (_env.isEmulator) {
-      // TODO: Implement direct REST API calls to emulator
-      // For now, we'll skip document fetching in emulator mode
-      return;
-    }
-
-    // Production mode only
-    try {
-      // Initialize Admin SDK
-      _adminApp = FirebaseApp.initializeApp(
-        options: AppOptions(
-          credential: Credential.fromApplicationDefaultCredentials(),
-          projectId: _env.projectId,
-        ),
-      );
-
-      // Create Firestore instance
-      _firestoreInstance = _adminApp!.firestore();
-    } catch (e) {
-      logger.warn('Failed to initialize Firebase Admin SDK: $e');
-    }
-  }
+  Firebase._({
+    required this.adminApp,
+    required this.firestoreAdmin,
+    required FirebaseEnv env,
+  }) : _env = env;
 
   final FirebaseEnv _env;
 
-  /// Get the Firestore instance
-  gfs.Firestore? get firestoreAdmin => _firestoreInstance;
+  /// The initialized Firebase Admin SDK application instance.
+  ///
+  /// This app represents the server-side SDK and has elevated privileges
+  /// corresponding to the environment's credentials.
+  final FirebaseApp adminApp;
 
-  /// Get the Firebase Admin App instance
-  FirebaseApp? get adminApp => _adminApp;
+  /// The Firestore admin client instance.
+  ///
+  /// Provides elevated server-side access to the Firestore database.
+  final gfs.Firestore firestoreAdmin;
 
   /// HTTPS triggers namespace.
   HttpsNamespace get https => HttpsNamespace(this);

--- a/lib/src/https/auth.dart
+++ b/lib/src/https/auth.dart
@@ -17,6 +17,8 @@ library;
 
 import 'dart:convert';
 
+import 'package:dart_firebase_admin/app_check.dart';
+import 'package:dart_firebase_admin/auth.dart';
 import 'package:dart_firebase_admin/dart_firebase_admin.dart';
 import 'package:shelf/shelf.dart';
 
@@ -59,8 +61,7 @@ final _jwtRegex = RegExp(
 /// Returns a tuple of (TokenStatus, AuthData?).
 Future<(TokenStatus, AuthData?)> extractAuthToken(
   Request request, {
-  required bool skipTokenVerification,
-  FirebaseApp? adminApp,
+  Auth? auth,
 }) async {
   final authorization = request.headers['authorization'];
   if (authorization == null || authorization.isEmpty) {
@@ -82,7 +83,7 @@ Future<(TokenStatus, AuthData?)> extractAuthToken(
     String uid;
     Map<String, dynamic>? decodedToken;
 
-    if (skipTokenVerification) {
+    if (auth == null) {
       // In emulator mode, just decode without verification
       decodedToken = _unsafeDecodeIdToken(idToken);
 
@@ -93,12 +94,6 @@ Future<(TokenStatus, AuthData?)> extractAuthToken(
           '';
     } else {
       // In production, verify the token using Firebase Admin SDK
-      if (adminApp == null) {
-        // Can't verify without admin app
-        return (TokenStatus.invalid, null);
-      }
-
-      final auth = adminApp.auth();
       final decoded = await auth.verifyIdToken(idToken);
       uid = decoded.uid;
       decodedToken = {
@@ -140,8 +135,7 @@ Future<(TokenStatus, AuthData?)> extractAuthToken(
 /// Returns a tuple of (TokenStatus, AppCheckData?).
 Future<(TokenStatus, AppCheckData?)> extractAppCheckToken(
   Request request, {
-  required bool skipTokenVerification,
-  FirebaseApp? adminApp,
+  AppCheck? appCheck,
 }) async {
   final appCheckToken = request.headers['x-firebase-appcheck'];
   if (appCheckToken == null || appCheckToken.isEmpty) {
@@ -151,7 +145,7 @@ Future<(TokenStatus, AppCheckData?)> extractAppCheckToken(
   try {
     String appId;
 
-    if (skipTokenVerification) {
+    if (appCheck == null) {
       // In emulator mode, just decode without verification
       final decodedToken = _unsafeDecodeAppCheckToken(appCheckToken);
 
@@ -161,12 +155,6 @@ Future<(TokenStatus, AppCheckData?)> extractAppCheckToken(
           '';
     } else {
       // In production, verify the token using Firebase Admin SDK
-      if (adminApp == null) {
-        // Can't verify without admin app
-        return (TokenStatus.invalid, null);
-      }
-
-      final appCheck = adminApp.appCheck();
       final decoded = await appCheck.verifyToken(appCheckToken);
       appId = decoded.appId;
     }
@@ -194,21 +182,15 @@ Future<
     AppCheckData? appCheckData,
   })
 >
-checkTokens(
-  Request request, {
-  required bool skipTokenVerification,
-  FirebaseApp? adminApp,
-}) async {
+checkTokens(Request request, {FirebaseApp? adminApp}) async {
   final (authStatus, authData) = await extractAuthToken(
     request,
-    skipTokenVerification: skipTokenVerification,
-    adminApp: adminApp,
+    auth: adminApp?.auth(),
   );
 
   final (appStatus, appCheckData) = await extractAppCheckToken(
     request,
-    skipTokenVerification: skipTokenVerification,
-    adminApp: adminApp,
+    appCheck: adminApp?.appCheck(),
   );
 
   return (

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -100,11 +100,12 @@ class HttpsNamespace extends FunctionsNamespace {
       }
 
       // Extract auth and app check tokens
-      final skipVerification = firebase.$env.skipTokenVerification;
+
       final tokens = await checkTokens(
         request,
-        skipTokenVerification: skipVerification,
-        adminApp: firebase.adminApp,
+        adminApp: firebase.$env.skipTokenVerification
+            ? null
+            : firebase.adminApp,
       );
 
       // Check for invalid auth token
@@ -180,11 +181,12 @@ class HttpsNamespace extends FunctionsNamespace {
       final body = await request.json as Map<String, dynamic>?;
 
       // Extract auth and app check tokens
-      final skipVerification = firebase.$env.skipTokenVerification;
+
       final tokens = await checkTokens(
         request,
-        skipTokenVerification: skipVerification,
-        adminApp: firebase.adminApp,
+        adminApp: firebase.$env.skipTokenVerification
+            ? null
+            : firebase.adminApp,
       );
 
       // Check for invalid auth token

--- a/test/unit/https_auth_test.dart
+++ b/test/unit/https_auth_test.dart
@@ -28,10 +28,7 @@ void main() {
     test('returns missing when no Authorization header', () async {
       final request = _createRequest();
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.missing);
       expect(auth, isNull);
@@ -44,10 +41,7 @@ void main() {
           headers: {'authorization': 'Basic abc123'},
         );
 
-        final (status, auth) = await extractAuthToken(
-          request,
-          skipTokenVerification: true,
-        );
+        final (status, auth) = await extractAuthToken(request);
 
         expect(status, TokenStatus.invalid);
         expect(auth, isNull);
@@ -58,10 +52,7 @@ void main() {
       final jwt = _createJwt({'email': 'test@example.com'});
       final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.invalid);
       expect(auth, isNull);
@@ -75,10 +66,7 @@ void main() {
       });
       final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.valid);
       expect(auth, isNotNull);
@@ -92,10 +80,7 @@ void main() {
       final jwt = _createJwt({'user_id': 'user456'});
       final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.valid);
       expect(auth?.uid, 'user456');
@@ -105,10 +90,7 @@ void main() {
       final jwt = _createJwt({'sub': 'user123'});
       final request = _createRequest(headers: {'authorization': 'bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.valid);
       expect(auth?.uid, 'user123');
@@ -119,10 +101,7 @@ void main() {
         headers: {'authorization': 'Bearer not-a-valid-jwt'},
       );
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.invalid);
       expect(auth, isNull);
@@ -132,10 +111,7 @@ void main() {
       final jwt = _createJwt({});
       final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, auth) = await extractAuthToken(request);
 
       expect(status, TokenStatus.invalid);
       expect(auth, isNull);
@@ -146,10 +122,7 @@ void main() {
     test('returns missing when no X-Firebase-AppCheck header', () async {
       final request = _createRequest();
 
-      final (status, appCheck) = await extractAppCheckToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, appCheck) = await extractAppCheckToken(request);
 
       expect(status, TokenStatus.missing);
       expect(appCheck, isNull);
@@ -159,10 +132,7 @@ void main() {
       final jwt = _createJwt({'other': 'value'});
       final request = _createRequest(headers: {'x-firebase-appcheck': jwt});
 
-      final (status, appCheck) = await extractAppCheckToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, appCheck) = await extractAppCheckToken(request);
 
       expect(status, TokenStatus.invalid);
       expect(appCheck, isNull);
@@ -172,10 +142,7 @@ void main() {
       final jwt = _createJwt({'sub': 'app123'});
       final request = _createRequest(headers: {'x-firebase-appcheck': jwt});
 
-      final (status, appCheck) = await extractAppCheckToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, appCheck) = await extractAppCheckToken(request);
 
       expect(status, TokenStatus.valid);
       expect(appCheck, isNotNull);
@@ -187,10 +154,7 @@ void main() {
       final jwt = _createJwt({'sub': 'sub-value', 'app_id': 'explicit-app-id'});
       final request = _createRequest(headers: {'x-firebase-appcheck': jwt});
 
-      final (status, appCheck) = await extractAppCheckToken(
-        request,
-        skipTokenVerification: true,
-      );
+      final (status, appCheck) = await extractAppCheckToken(request);
 
       expect(status, TokenStatus.valid);
       expect(appCheck?.appId, 'explicit-app-id');
@@ -208,7 +172,7 @@ void main() {
         },
       );
 
-      final result = await checkTokens(request, skipTokenVerification: true);
+      final result = await checkTokens(request);
 
       expect(result.result.auth, TokenStatus.valid);
       expect(result.result.app, TokenStatus.valid);
@@ -219,7 +183,7 @@ void main() {
     test('returns missing status when headers are absent', () async {
       final request = _createRequest();
 
-      final result = await checkTokens(request, skipTokenVerification: true);
+      final result = await checkTokens(request);
 
       expect(result.result.auth, TokenStatus.missing);
       expect(result.result.app, TokenStatus.missing);
@@ -237,7 +201,7 @@ void main() {
         },
       );
 
-      final result = await checkTokens(request, skipTokenVerification: true);
+      final result = await checkTokens(request);
 
       expect(result.result.auth, TokenStatus.valid);
       expect(result.result.app, TokenStatus.invalid);


### PR DESCRIPTION
- Replaced nullable  and  accessors with  properties.
- Removed the `try...catch` wrapper around `FirebaseApp.initializeApp()` to fail hard on initialization errors rather than suppressing them.
- Removed the early emulator exit check; the SDK now proceeds with resolving default credentials even under emulator conditions.
- Refactored token extractors (`extractAuthToken`, `extractAppCheckToken`) to allow a nullable `auth` or `appCheck` instead replacing the the `skip` bit.
- Updated `https_auth_test.dart` to be a lot more simple.
