### PR TITLE
chore: update copyright headers to Google LLC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/validate-local.sh
+++ b/.github/workflows/validate-local.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/alerts/bin/server.dart
+++ b/example/alerts/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/alerts/pubspec.yaml
+++ b/example/alerts/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/auth/bin/server.dart
+++ b/example/auth/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/auth/pubspec.yaml
+++ b/example/auth/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/client_app/index.html
+++ b/example/client_app/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2026 Firebase
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/example/database/bin/server.dart
+++ b/example/database/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/database/pubspec.yaml
+++ b/example/database/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/eventarc/bin/server.dart
+++ b/example/eventarc/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/eventarc/pubspec.yaml
+++ b/example/eventarc/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/firestore/bin/server.dart
+++ b/example/firestore/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/firestore/pubspec.yaml
+++ b/example/firestore/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/firestore_test/bin/server.dart
+++ b/example/firestore_test/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/firestore_test/build.yaml
+++ b/example/firestore_test/build.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/firestore_test/pubspec.yaml
+++ b/example/firestore_test/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/firestore_test/test/e2e/firestore_triggers_test.dart
+++ b/example/firestore_test/test/e2e/firestore_triggers_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/firestore_test/test_trigger.js
+++ b/example/firestore_test/test_trigger.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 Firebase
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/firestore_test/trigger_test.sh
+++ b/example/firestore_test/trigger_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/https/bin/server.dart
+++ b/example/https/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/https/pubspec.yaml
+++ b/example/https/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/pubsub/bin/server.dart
+++ b/example/pubsub/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/pubsub/pubspec.yaml
+++ b/example/pubsub/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/remoteconfig/bin/server.dart
+++ b/example/remoteconfig/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/remoteconfig/pubspec.yaml
+++ b/example/remoteconfig/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/scheduler/bin/server.dart
+++ b/example/scheduler/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/scheduler/pubspec.yaml
+++ b/example/scheduler/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/storage/bin/server.dart
+++ b/example/storage/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/storage/pubspec.yaml
+++ b/example/storage/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/tasks/bin/server.dart
+++ b/example/tasks/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/tasks/pubspec.yaml
+++ b/example/tasks/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/testlab/bin/server.dart
+++ b/example/testlab/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/testlab/pubspec.yaml
+++ b/example/testlab/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/header_template.txt
+++ b/header_template.txt
@@ -1,4 +1,4 @@
-Copyright 2026 Firebase
+Copyright 2026 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/firebase_functions.dart
+++ b/lib/firebase_functions.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/params.dart
+++ b/lib/params.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/alert_event.dart
+++ b/lib/src/alerts/alert_event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/alert_type.dart
+++ b/lib/src/alerts/alert_type.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/alerts.dart
+++ b/lib/src/alerts/alerts.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/alerts_namespace.dart
+++ b/lib/src/alerts/alerts_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/app_distribution_namespace.dart
+++ b/lib/src/alerts/app_distribution_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/app_distribution_payloads.dart
+++ b/lib/src/alerts/app_distribution_payloads.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/billing_namespace.dart
+++ b/lib/src/alerts/billing_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/billing_payloads.dart
+++ b/lib/src/alerts/billing_payloads.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/crashlytics_namespace.dart
+++ b/lib/src/alerts/crashlytics_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/crashlytics_payloads.dart
+++ b/lib/src/alerts/crashlytics_payloads.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/options.dart
+++ b/lib/src/alerts/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/performance_namespace.dart
+++ b/lib/src/alerts/performance_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/alerts/performance_payloads.dart
+++ b/lib/src/alerts/performance_payloads.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/builder/manifest.dart
+++ b/lib/src/builder/manifest.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/builder/spec.dart
+++ b/lib/src/builder/spec.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/change.dart
+++ b/lib/src/common/change.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/cloud_event.dart
+++ b/lib/src/common/cloud_event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/cloud_run_id.dart
+++ b/lib/src/common/cloud_run_id.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/environment.dart
+++ b/lib/src/common/environment.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/expression.dart
+++ b/lib/src/common/expression.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/on_init.dart
+++ b/lib/src/common/on_init.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/options.dart
+++ b/lib/src/common/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/params.dart
+++ b/lib/src/common/params.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/common/utilities.dart
+++ b/lib/src/common/utilities.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/database/data_snapshot.dart
+++ b/lib/src/database/data_snapshot.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/database/database.dart
+++ b/lib/src/database/database.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/database/database_namespace.dart
+++ b/lib/src/database/database_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/database/event.dart
+++ b/lib/src/database/event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/database/options.dart
+++ b/lib/src/database/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/eventarc/eventarc.dart
+++ b/lib/src/eventarc/eventarc.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/eventarc/eventarc_namespace.dart
+++ b/lib/src/eventarc/eventarc_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/eventarc/options.dart
+++ b/lib/src/eventarc/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firestore/document_snapshot.dart
+++ b/lib/src/firestore/document_snapshot.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firestore/event.dart
+++ b/lib/src/firestore/event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firestore/firestore.dart
+++ b/lib/src/firestore/firestore.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firestore/firestore_namespace.dart
+++ b/lib/src/firestore/firestore_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firestore/options.dart
+++ b/lib/src/firestore/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/firestore/protobuf_parser.dart
+++ b/lib/src/firestore/protobuf_parser.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/https/auth.dart
+++ b/lib/src/https/auth.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/https/callable.dart
+++ b/lib/src/https/callable.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/https/error.dart
+++ b/lib/src/https/error.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/https/https.dart
+++ b/lib/src/https/https.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/https/options.dart
+++ b/lib/src/https/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/auth_blocking_event.dart
+++ b/lib/src/identity/auth_blocking_event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/auth_user_record.dart
+++ b/lib/src/identity/auth_user_record.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/identity.dart
+++ b/lib/src/identity/identity.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/identity_namespace.dart
+++ b/lib/src/identity/identity_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/options.dart
+++ b/lib/src/identity/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/responses.dart
+++ b/lib/src/identity/responses.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/identity/token_verifier.dart
+++ b/lib/src/identity/token_verifier.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/logger/logger.dart
+++ b/lib/src/logger/logger.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/pubsub/message.dart
+++ b/lib/src/pubsub/message.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/pubsub/options.dart
+++ b/lib/src/pubsub/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/pubsub/pubsub.dart
+++ b/lib/src/pubsub/pubsub.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/pubsub/pubsub_namespace.dart
+++ b/lib/src/pubsub/pubsub_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/remote_config/config_update_data.dart
+++ b/lib/src/remote_config/config_update_data.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/remote_config/options.dart
+++ b/lib/src/remote_config/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/remote_config/remote_config.dart
+++ b/lib/src/remote_config/remote_config.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/remote_config/remote_config_namespace.dart
+++ b/lib/src/remote_config/remote_config_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/scheduler/options.dart
+++ b/lib/src/scheduler/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/scheduler/scheduled_event.dart
+++ b/lib/src/scheduler/scheduled_event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/scheduler/scheduler.dart
+++ b/lib/src/scheduler/scheduler.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/scheduler/scheduler_namespace.dart
+++ b/lib/src/scheduler/scheduler_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/storage/options.dart
+++ b/lib/src/storage/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/storage/storage.dart
+++ b/lib/src/storage/storage.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/storage/storage_event.dart
+++ b/lib/src/storage/storage_event.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/storage/storage_namespace.dart
+++ b/lib/src/storage/storage_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/storage/storage_object_data.dart
+++ b/lib/src/storage/storage_object_data.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/tasks/options.dart
+++ b/lib/src/tasks/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/tasks/task_request.dart
+++ b/lib/src/tasks/task_request.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/tasks/tasks.dart
+++ b/lib/src/tasks/tasks.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/tasks/tasks_namespace.dart
+++ b/lib/src/tasks/tasks_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/test_lab/options.dart
+++ b/lib/src/test_lab/options.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/test_lab/test_lab.dart
+++ b/lib/src/test_lab/test_lab.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/test_lab/test_lab_namespace.dart
+++ b/lib/src/test_lab/test_lab_namespace.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/test_lab/test_matrix_completed_data.dart
+++ b/lib/src/test_lab/test_matrix_completed_data.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/e2e/e2e_test.dart
+++ b/test/e2e/e2e_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/auth_client.dart
+++ b/test/e2e/helpers/auth_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/database_client.dart
+++ b/test/e2e/helpers/database_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/emulator.dart
+++ b/test/e2e/helpers/emulator.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/firestore_client.dart
+++ b/test/e2e/helpers/firestore_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/http_client.dart
+++ b/test/e2e/helpers/http_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/pubsub_client.dart
+++ b/test/e2e/helpers/pubsub_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/storage_client.dart
+++ b/test/e2e/helpers/storage_client.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/helpers/test_client_base.dart
+++ b/test/e2e/helpers/test_client_base.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/database_tests.dart
+++ b/test/e2e/tests/database_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/firestore_tests.dart
+++ b/test/e2e/tests/firestore_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/https_oncall_tests.dart
+++ b/test/e2e/tests/https_oncall_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/identity_tests.dart
+++ b/test/e2e/tests/identity_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/integration_tests.dart
+++ b/test/e2e/tests/integration_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/pubsub_tests.dart
+++ b/test/e2e/tests/pubsub_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/scheduler_tests.dart
+++ b/test/e2e/tests/scheduler_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/tests/storage_tests.dart
+++ b/test/e2e/tests/storage_tests.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/fixtures/dart_reference/pubspec.yaml
+++ b/test/fixtures/dart_reference/pubspec.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 Firebase
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/fixtures/nodejs_reference/extract-manifest.js
+++ b/test/fixtures/nodejs_reference/extract-manifest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 Firebase
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/nodejs_reference/index.js
+++ b/test/fixtures/nodejs_reference/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 Firebase
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/alerts_test.dart
+++ b/test/unit/alerts_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/error_logging_test.dart
+++ b/test/unit/error_logging_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/https_auth_test.dart
+++ b/test/unit/https_auth_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/https_callable_test.dart
+++ b/test/unit/https_callable_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/https_error_test.dart
+++ b/test/unit/https_error_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/identity_test.dart
+++ b/test/unit/identity_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/logger_test.dart
+++ b/test/unit/logger_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/on_init_test.dart
+++ b/test/unit/on_init_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/params_test.dart
+++ b/test/unit/params_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/protobuf_parser_test.dart
+++ b/test/unit/protobuf_parser_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/remote_config_test.dart
+++ b/test/unit/remote_config_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/scheduler_namespace_test.dart
+++ b/test/unit/scheduler_namespace_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/server_test.dart
+++ b/test/unit/server_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unit/token_verifier_test.dart
+++ b/test/unit/token_verifier_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Firebase
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Align header template and source file copyright owner text with legal guidance by replacing "Copyright 2026 Firebase" with "Copyright 2026 Google LLC" across the repository.