### PR TITLE
chore: use firstOrNull extension

### DIFF
--- a/lib/src/identity/auth_blocking_event.dart
+++ b/lib/src/identity/auth_blocking_event.dart
@@ -56,10 +56,7 @@ enum EmailType {
   /// Creates an EmailType from a string value.
   static EmailType? fromString(String? value) {
     if (value == null) return null;
-    return EmailType.values.cast<EmailType?>().firstWhere(
-      (e) => e!.value == value,
-      orElse: () => null,
-    );
+    return EmailType.values.where((e) => e.value == value).firstOrNull;
   }
 }
 
@@ -82,10 +79,7 @@ enum SmsType {
   /// Creates an SmsType from a string value.
   static SmsType? fromString(String? value) {
     if (value == null) return null;
-    return SmsType.values.cast<SmsType?>().firstWhere(
-      (e) => e!.value == value,
-      orElse: () => null,
-    );
+    return SmsType.values.where((e) => e.value == value).firstOrNull;
   }
 }
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -156,8 +156,8 @@ FutureOr<Response> _routeToTargetFunction(
 
   // Find the function with matching name
   final targetFunction = functions
-      .cast<FirebaseFunctionDeclaration?>()
-      .firstWhere((f) => f?.name == functionTarget, orElse: () => null);
+      .where((f) => f.name == functionTarget)
+      .firstOrNull;
 
   if (targetFunction == null) {
     return Response.notFound(


### PR DESCRIPTION
Much cleaner than doing the cast<XYZ?> etc etc
