### PR TITLE
chore: DRY up CORS headers for emulator mode

### DIFF
--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -84,7 +84,7 @@ Future<void> fireUp(List<String> args, FunctionsRunner runner) async {
 Handler _corsMiddleware(Handler innerHandler) => (request) {
   // Handle preflight OPTIONS requests
   if (request.method.toUpperCase() == 'OPTIONS') {
-    return Response.ok('', headers: _corsAnyOriginHeaders);
+    return Response(204, headers: _corsAnyOriginHeaders);
   }
 
   return Future.sync(() => innerHandler(request)).then((response) {


### PR DESCRIPTION
Instead of always injecting the CORS middleware and then switching the behavior WITHIN it, just add it when it's needed.

Also DRY'd up the headers.