### PR TITLE
refactor(https): change token extraction functions to accept a Map of headers instead of a Request object

### DIFF
--- a/lib/src/https/auth.dart
+++ b/lib/src/https/auth.dart
@@ -20,7 +20,6 @@ import 'dart:convert';
 import 'package:dart_firebase_admin/app_check.dart';
 import 'package:dart_firebase_admin/auth.dart';
 import 'package:dart_firebase_admin/dart_firebase_admin.dart';
-import 'package:shelf/shelf.dart';
 
 import 'callable.dart';
 
@@ -60,10 +59,10 @@ final _jwtRegex = RegExp(
 ///
 /// Returns a tuple of (TokenStatus, AuthData?).
 Future<(TokenStatus, AuthData?)> extractAuthToken(
-  Request request, {
+  Map<String, String> headers, {
   Auth? auth,
 }) async {
-  final authorization = request.headers['authorization'];
+  final authorization = headers['authorization'];
   if (authorization == null || authorization.isEmpty) {
     return (TokenStatus.missing, null);
   }
@@ -134,10 +133,10 @@ Future<(TokenStatus, AuthData?)> extractAuthToken(
 ///
 /// Returns a tuple of (TokenStatus, AppCheckData?).
 Future<(TokenStatus, AppCheckData?)> extractAppCheckToken(
-  Request request, {
+  Map<String, String> headers, {
   AppCheck? appCheck,
 }) async {
-  final appCheckToken = request.headers['x-firebase-appcheck'];
+  final appCheckToken = headers['x-firebase-appcheck'];
   if (appCheckToken == null || appCheckToken.isEmpty) {
     return (TokenStatus.missing, null);
   }
@@ -182,14 +181,14 @@ Future<
     AppCheckData? appCheckData,
   })
 >
-checkTokens(Request request, {FirebaseApp? adminApp}) async {
+checkTokens(Map<String, String> headers, {FirebaseApp? adminApp}) async {
   final (authStatus, authData) = await extractAuthToken(
-    request,
+    headers,
     auth: adminApp?.auth(),
   );
 
   final (appStatus, appCheckData) = await extractAppCheckToken(
-    request,
+    headers,
     appCheck: adminApp?.appCheck(),
   );
 

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -102,7 +102,7 @@ class HttpsNamespace extends FunctionsNamespace {
       // Extract auth and app check tokens
 
       final tokens = await checkTokens(
-        request,
+        request.headers,
         adminApp: firebase.$env.skipTokenVerification
             ? null
             : firebase.adminApp,
@@ -183,7 +183,7 @@ class HttpsNamespace extends FunctionsNamespace {
       // Extract auth and app check tokens
 
       final tokens = await checkTokens(
-        request,
+        request.headers,
         adminApp: firebase.$env.skipTokenVerification
             ? null
             : firebase.adminApp,

--- a/test/unit/https_auth_test.dart
+++ b/test/unit/https_auth_test.dart
@@ -16,7 +16,6 @@ import 'dart:convert';
 
 import 'package:firebase_functions/src/https/auth.dart';
 import 'package:firebase_functions/src/https/callable.dart';
-import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -26,9 +25,7 @@ void main() {
 
   group('extractAuthToken', () {
     test('returns missing when no Authorization header', () async {
-      final request = _createRequest();
-
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({});
 
       expect(status, TokenStatus.missing);
       expect(auth, isNull);
@@ -37,11 +34,9 @@ void main() {
     test(
       'returns invalid when Authorization header is not Bearer format',
       () async {
-        final request = _createRequest(
-          headers: {'authorization': 'Basic abc123'},
-        );
-
-        final (status, auth) = await extractAuthToken(request);
+        final (status, auth) = await extractAuthToken({
+          'authorization': 'Basic abc123',
+        });
 
         expect(status, TokenStatus.invalid);
         expect(auth, isNull);
@@ -50,9 +45,10 @@ void main() {
 
     test('returns invalid when token has no uid/sub claim', () async {
       final jwt = _createJwt({'email': 'test@example.com'});
-      final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({
+        'authorization': 'Bearer $jwt',
+      });
 
       expect(status, TokenStatus.invalid);
       expect(auth, isNull);
@@ -64,9 +60,10 @@ void main() {
         'email': 'test@example.com',
         'custom_claim': 'value',
       });
-      final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({
+        'authorization': 'Bearer $jwt',
+      });
 
       expect(status, TokenStatus.valid);
       expect(auth, isNotNull);
@@ -78,9 +75,10 @@ void main() {
 
     test('extracts uid from user_id claim as fallback', () async {
       final jwt = _createJwt({'user_id': 'user456'});
-      final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({
+        'authorization': 'Bearer $jwt',
+      });
 
       expect(status, TokenStatus.valid);
       expect(auth?.uid, 'user456');
@@ -88,20 +86,19 @@ void main() {
 
     test('handles case-insensitive Bearer prefix', () async {
       final jwt = _createJwt({'sub': 'user123'});
-      final request = _createRequest(headers: {'authorization': 'bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({
+        'authorization': 'bearer $jwt',
+      });
 
       expect(status, TokenStatus.valid);
       expect(auth?.uid, 'user123');
     });
 
     test('returns invalid for malformed JWT', () async {
-      final request = _createRequest(
-        headers: {'authorization': 'Bearer not-a-valid-jwt'},
-      );
-
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({
+        'authorization': 'Bearer not-a-valid-jwt',
+      });
 
       expect(status, TokenStatus.invalid);
       expect(auth, isNull);
@@ -109,9 +106,10 @@ void main() {
 
     test('returns invalid for JWT with empty payload', () async {
       final jwt = _createJwt({});
-      final request = _createRequest(headers: {'authorization': 'Bearer $jwt'});
 
-      final (status, auth) = await extractAuthToken(request);
+      final (status, auth) = await extractAuthToken({
+        'authorization': 'Bearer $jwt',
+      });
 
       expect(status, TokenStatus.invalid);
       expect(auth, isNull);
@@ -120,9 +118,7 @@ void main() {
 
   group('extractAppCheckToken', () {
     test('returns missing when no X-Firebase-AppCheck header', () async {
-      final request = _createRequest();
-
-      final (status, appCheck) = await extractAppCheckToken(request);
+      final (status, appCheck) = await extractAppCheckToken({});
 
       expect(status, TokenStatus.missing);
       expect(appCheck, isNull);
@@ -130,9 +126,10 @@ void main() {
 
     test('returns invalid when token has no sub claim', () async {
       final jwt = _createJwt({'other': 'value'});
-      final request = _createRequest(headers: {'x-firebase-appcheck': jwt});
 
-      final (status, appCheck) = await extractAppCheckToken(request);
+      final (status, appCheck) = await extractAppCheckToken({
+        'x-firebase-appcheck': jwt,
+      });
 
       expect(status, TokenStatus.invalid);
       expect(appCheck, isNull);
@@ -140,9 +137,10 @@ void main() {
 
     test('returns valid with AppCheckData for valid token', () async {
       final jwt = _createJwt({'sub': 'app123'});
-      final request = _createRequest(headers: {'x-firebase-appcheck': jwt});
 
-      final (status, appCheck) = await extractAppCheckToken(request);
+      final (status, appCheck) = await extractAppCheckToken({
+        'x-firebase-appcheck': jwt,
+      });
 
       expect(status, TokenStatus.valid);
       expect(appCheck, isNotNull);
@@ -152,9 +150,10 @@ void main() {
 
     test('extracts app_id from explicit claim', () async {
       final jwt = _createJwt({'sub': 'sub-value', 'app_id': 'explicit-app-id'});
-      final request = _createRequest(headers: {'x-firebase-appcheck': jwt});
 
-      final (status, appCheck) = await extractAppCheckToken(request);
+      final (status, appCheck) = await extractAppCheckToken({
+        'x-firebase-appcheck': jwt,
+      });
 
       expect(status, TokenStatus.valid);
       expect(appCheck?.appId, 'explicit-app-id');
@@ -165,14 +164,11 @@ void main() {
     test('returns both auth and app check data when present', () async {
       final authJwt = _createJwt({'sub': 'user123'});
       final appCheckJwt = _createJwt({'sub': 'app123'});
-      final request = _createRequest(
-        headers: {
-          'authorization': 'Bearer $authJwt',
-          'x-firebase-appcheck': appCheckJwt,
-        },
-      );
 
-      final result = await checkTokens(request);
+      final result = await checkTokens({
+        'authorization': 'Bearer $authJwt',
+        'x-firebase-appcheck': appCheckJwt,
+      });
 
       expect(result.result.auth, TokenStatus.valid);
       expect(result.result.app, TokenStatus.valid);
@@ -181,9 +177,7 @@ void main() {
     });
 
     test('returns missing status when headers are absent', () async {
-      final request = _createRequest();
-
-      final result = await checkTokens(request);
+      final result = await checkTokens({});
 
       expect(result.result.auth, TokenStatus.missing);
       expect(result.result.app, TokenStatus.missing);
@@ -194,14 +188,11 @@ void main() {
     test('handles mixed valid and invalid tokens', () async {
       final authJwt = _createJwt({'sub': 'user123'});
       final invalidAppCheckJwt = _createJwt({'no_sub': 'value'});
-      final request = _createRequest(
-        headers: {
-          'authorization': 'Bearer $authJwt',
-          'x-firebase-appcheck': invalidAppCheckJwt,
-        },
-      );
 
-      final result = await checkTokens(request);
+      final result = await checkTokens({
+        'authorization': 'Bearer $authJwt',
+        'x-firebase-appcheck': invalidAppCheckJwt,
+      });
 
       expect(result.result.auth, TokenStatus.valid);
       expect(result.result.app, TokenStatus.invalid);
@@ -266,13 +257,4 @@ String _createJwt(Map<String, dynamic> payload) {
   const signature = 'dummysignature';
 
   return '$header.$body.$signature';
-}
-
-/// Creates a test request with optional headers.
-Request _createRequest({Map<String, String>? headers}) {
-  return Request(
-    'POST',
-    Uri.parse('http://localhost:8080/test'),
-    headers: headers,
-  );
 }


### PR DESCRIPTION
Decouples the authentication logic from `package:shelf` by passing the headers map directly. This simplifies the API and makes testing easier without needing to construct full shelf Request objects.

- Update `extractAuthToken`, `extractAppCheckToken`, and `checkTokens` to take `Map<String, String>`.
- Update `HttpsNamespace` usage to pass `request.headers`.
- Update unit tests to use raw Map literals for headers.
