### PR TITLE
Fix broken streaming responses (deadlocks and cast errors)

### DIFF
--- a/lib/src/https/callable.dart
+++ b/lib/src/https/callable.dart
@@ -270,11 +270,12 @@ class CallableResponse<T extends Object> {
         } else {
           writeSSE(InternalError().toErrorResponse());
         }
+        unawaited(closeStream());
       },
       onDone: () async {
         await closeStream();
       },
-      cancelOnError: false,
+      cancelOnError: true,
     );
   }
 

--- a/lib/src/https/callable.dart
+++ b/lib/src/https/callable.dart
@@ -292,7 +292,7 @@ class CallableResponse<T extends Object> {
     }
 
     try {
-      _streamController!.add(_encodeSSE({'result': chunk}));
+      _streamController!.add(_encodeSSE({'message': chunk}));
 
       // Reset heartbeat timer after successful write
       if (heartbeatSeconds != null && heartbeatSeconds! > 0) {

--- a/lib/src/https/callable.dart
+++ b/lib/src/https/callable.dart
@@ -15,8 +15,12 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:shelf/shelf.dart';
+
+import '../logger/logger.dart';
+import 'error.dart';
 
 /// JSON decoder function type.
 typedef JsonDecoder<T extends Object?> = T Function(Map<String, dynamic>);
@@ -193,18 +197,30 @@ class CallableRequest<T extends Object?> {
 /// ```
 class CallableResponse<T extends Object> {
   CallableResponse({required this.acceptsStreaming, this.heartbeatSeconds});
+
+  static final _dataPrefix = utf8.encode('data: ');
+  static final _newlineSuffix = utf8.encode('\n\n');
+  static final _pingBytes = utf8.encode(': ping\n\n');
   final bool acceptsStreaming;
   final int? heartbeatSeconds;
 
-  StreamController<String>? _streamController;
+  StreamController<List<int>>? _streamController;
   Response? _streamingResponse;
   Timer? _heartbeatTimer;
   StreamSubscription<CallableResult<T>>? _streamSubscription;
   bool _aborted = false;
+  bool _isUsingResponseStream = false;
+
+  /// Whether [stream] was called to set up background streaming.
+  bool get isUsingResponseStream => _isUsingResponseStream;
 
   /// Initializes SSE streaming.
   void initializeStreaming() {
-    _streamController = StreamController<String>();
+    _streamController = StreamController<List<int>>(
+      onCancel: () {
+        abort();
+      },
+    );
     _streamingResponse = Response.ok(
       _streamController!.stream,
       headers: {
@@ -241,15 +257,22 @@ class CallableResponse<T extends Object> {
       return;
     }
 
+    _isUsingResponseStream = true;
+
     _streamSubscription = dataStream.listen(
       (result) {
         unawaited(sendChunk(result.data));
       },
       onError: (Object error) {
-        // Log error but don't close the stream - let handler complete
+        logger.error('Error in data stream', {'error': error.toString()});
+        if (error is HttpsError) {
+          writeSSE(error.toErrorResponse());
+        } else {
+          writeSSE(InternalError().toErrorResponse());
+        }
       },
-      onDone: () {
-        // Stream completed naturally
+      onDone: () async {
+        await closeStream();
       },
       cancelOnError: false,
     );
@@ -269,8 +292,7 @@ class CallableResponse<T extends Object> {
     }
 
     try {
-      final formattedData = _encodeSSE({'message': chunk});
-      _streamController!.add(formattedData);
+      _streamController!.add(_encodeSSE({'result': chunk}));
 
       // Reset heartbeat timer after successful write
       if (heartbeatSeconds != null && heartbeatSeconds! > 0) {
@@ -295,6 +317,8 @@ class CallableResponse<T extends Object> {
   Future<void> closeStream() async {
     await _streamSubscription?.cancel();
     _streamSubscription = null;
+
+    clearHeartbeat();
 
     if (_streamController != null && !_streamController!.isClosed) {
       await _streamController!.close();
@@ -333,16 +357,20 @@ class CallableResponse<T extends Object> {
       if (!_aborted &&
           _streamController != null &&
           !_streamController!.isClosed) {
-        _streamController!.add(': ping\n\n');
+        _streamController!.add(_pingBytes);
         _scheduleHeartbeat();
       }
     });
   }
 
   /// Encodes data as SSE format.
-  String _encodeSSE(Map<String, dynamic> data) {
-    final encoded = jsonEncode(data);
-    return 'data: $encoded\n\n';
+  List<int> _encodeSSE(Map<String, dynamic> data) {
+    final jsonBytes = json.fuse(utf8).encode(data);
+    return (BytesBuilder(copy: false)
+          ..add(_dataPrefix)
+          ..add(jsonBytes)
+          ..add(_newlineSuffix))
+        .takeBytes();
   }
 }
 

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -278,7 +278,9 @@ class HttpsNamespace extends FunctionsNamespace {
       if (callableRequest.acceptsStreaming && !callableResponse.aborted) {
         final finalResult = {'result': extractResultData(result)};
         callableResponse.writeSSE(finalResult);
-        await callableResponse.closeStream();
+        if (!callableResponse.isUsingResponseStream) {
+          unawaited(callableResponse.closeStream());
+        }
         return callableResponse.streamingResponse!;
       }
 
@@ -288,7 +290,7 @@ class HttpsNamespace extends FunctionsNamespace {
       // Handle HttpsError - use SSE format if streaming
       if (callableRequest.acceptsStreaming && !callableResponse.aborted) {
         callableResponse.writeSSE(e.toErrorResponse());
-        await callableResponse.closeStream();
+        unawaited(callableResponse.closeStream());
         return callableResponse.streamingResponse!;
       }
 
@@ -299,13 +301,11 @@ class HttpsNamespace extends FunctionsNamespace {
 
       if (callableRequest.acceptsStreaming && !callableResponse.aborted) {
         callableResponse.writeSSE(error.toErrorResponse());
-        await callableResponse.closeStream();
+        unawaited(callableResponse.closeStream());
         return callableResponse.streamingResponse!;
       }
 
       return error.toShelfResponse();
-    } finally {
-      callableResponse.clearHeartbeat();
     }
   }
 }

--- a/test/unit/https_callable_test.dart
+++ b/test/unit/https_callable_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async' show unawaited;
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -379,6 +379,33 @@ void main() {
 
       // Clean up
       response.clearHeartbeat();
+    });
+
+    test('stream method stops forwarding after error', () async {
+      final response = CallableResponse<int>(acceptsStreaming: true);
+      response.initializeStreaming();
+
+      final controller = StreamController<CallableResult<int>>();
+      response.stream(controller.stream);
+
+      final stream = response.streamingResponse!.read();
+
+      controller.add(CallableResult(1));
+      controller.addError(Exception('test error'));
+      controller.add(CallableResult(2));
+      unawaited(controller.close());
+
+      final events = await stream.toList();
+      final decoded = events.map((e) => utf8.decode(e)).toList();
+
+      // We expect only 2 events: the first data and the error.
+      // The second data item should not be sent because the stream should close on error.
+      expect(decoded.length, 2);
+      expect(decoded[0], 'data: {"message":1}\n\n');
+      expect(
+        decoded[1],
+        contains('"status":"INTERNAL"'),
+      );
     });
 
     test('stream method does nothing when not accepting streaming', () async {

--- a/test/unit/https_callable_test.dart
+++ b/test/unit/https_callable_test.dart
@@ -402,10 +402,7 @@ void main() {
       // The second data item should not be sent because the stream should close on error.
       expect(decoded.length, 2);
       expect(decoded[0], 'data: {"message":1}\n\n');
-      expect(
-        decoded[1],
-        contains('"status":"INTERNAL"'),
-      );
+      expect(decoded[1], contains('"status":"INTERNAL"'));
     });
 
     test('stream method does nothing when not accepting streaming', () async {

--- a/test/unit/https_callable_test.dart
+++ b/test/unit/https_callable_test.dart
@@ -288,22 +288,20 @@ void main() {
       expect(success, isFalse);
     });
 
-    test('sendChunk sends SSE formatted data', () async {
+    test('sendChunk sends SSE formatted data with message key', () async {
       final response = CallableResponse<String>(acceptsStreaming: true);
       response.initializeStreaming();
+
+      final stream = response.streamingResponse!.read();
 
       // Send a chunk - should succeed
       final success = await response.sendChunk('hello');
       expect(success, isTrue);
 
-      // The streamingResponse should have correct headers
-      expect(
-        response.streamingResponse!.headers['Content-Type'],
-        'text/event-stream',
-      );
+      final events = await stream.take(1).toList();
+      expect(utf8.decode(events.first), 'data: {"message":"hello"}\n\n');
 
-      // Clean up without awaiting (since no consumer)
-      response.clearHeartbeat();
+      unawaited(response.closeStream());
     });
 
     test('writeSSE sends raw SSE data', () {

--- a/test/unit/https_callable_test.dart
+++ b/test/unit/https_callable_test.dart
@@ -399,6 +399,36 @@ void main() {
       // Stream should not have been consumed
       expect(streamCompleted, isFalse);
     });
+
+    test('heartbeat sends ping when idle', () async {
+      final response = CallableResponse<String>(
+        acceptsStreaming: true,
+        heartbeatSeconds: 1,
+      );
+      response.initializeStreaming();
+
+      final stream = response.streamingResponse!.read();
+
+      // Wait for 1.5 seconds to ensure heartbeat fires
+      await Future<void>.delayed(const Duration(milliseconds: 1500));
+
+      final events = await stream.take(1).toList();
+      expect(events.first, utf8.encode(': ping\n\n'));
+
+      unawaited(response.closeStream());
+    });
+
+    test('client disconnect aborts stream', () async {
+      final response = CallableResponse<String>(acceptsStreaming: true);
+      response.initializeStreaming();
+
+      final stream = response.streamingResponse!.read();
+      final subscription = stream.listen((_) {});
+
+      await subscription.cancel();
+
+      expect(response.aborted, isTrue);
+    });
   });
 
   group('decode', () {

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -14,6 +14,7 @@
 
 // ignore_for_file: avoid_dynamic_calls
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:firebase_functions/src/common/environment.dart';
@@ -271,6 +272,133 @@ void main() {
 
         final body = jsonDecode(await response.readAsString());
         expect(body['result'], {'status': 'ok', 'count': 42});
+      });
+
+      group('streaming handling', () {
+        test('catches HttpsError and returns SSE error', () async {
+          https.onCall(name: 'streamErrorFunction', (request, response) async {
+            throw InvalidArgumentError('Invalid data');
+          });
+
+          final func = _findFunction(firebase, 'stream-error-function')!;
+          final request = createCallableRequest(
+            headers: {'accept': 'text/event-stream'},
+          );
+          final response = await func.handler(request);
+
+          expect(response.statusCode, 200);
+          expect(response.headers['content-type'], 'text/event-stream');
+
+          final body = await response.readAsString();
+          expect(body, startsWith('data: {'));
+          expect(body, contains('"status":"INVALID_ARGUMENT"'));
+          expect(body, contains('"message":"Invalid data"'));
+        });
+
+        test(
+          'catches unexpected exceptions and returns SSE internal error',
+          () async {
+            https.onCall(name: 'streamCrashFunction', (
+              request,
+              response,
+            ) async {
+              throw Exception('Unexpected crash');
+            });
+
+            final func = _findFunction(firebase, 'stream-crash-function')!;
+            final request = createCallableRequest(
+              headers: {'accept': 'text/event-stream'},
+            );
+            final response = await func.handler(request);
+
+            expect(response.statusCode, 200);
+            expect(response.headers['content-type'], 'text/event-stream');
+
+            final body = await response.readAsString();
+            expect(body, startsWith('data: {'));
+            expect(body, contains('"status":"INTERNAL"'));
+            expect(body, contains('"message":"An unexpected error occurred."'));
+          },
+        );
+
+        test('success streaming returns SSE data', () async {
+          https.onCall(name: 'streamSuccessFunction', (
+            request,
+            response,
+          ) async {
+            return CallableResult('success');
+          });
+
+          final func = _findFunction(firebase, 'stream-success-function')!;
+          final request = createCallableRequest(
+            headers: {'accept': 'text/event-stream'},
+          );
+          final response = await func.handler(request);
+
+          expect(response.statusCode, 200);
+          expect(response.headers['content-type'], 'text/event-stream');
+
+          final body = await response.readAsString();
+          expect(body, startsWith('data: {'));
+          expect(body, contains('"result":"success"'));
+        });
+
+        test('catches error emitted by stream and returns SSE error', () async {
+          https.onCall(name: 'streamStreamErrorFunction', (
+            request,
+            response,
+          ) async {
+            final controller = StreamController<CallableResult<String>>();
+            response.stream(controller.stream);
+
+            controller.add(CallableResult('part 1'));
+            controller.addError(InvalidArgumentError('Invalid part 2'));
+            unawaited(controller.close());
+
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            return CallableResult('done');
+          });
+
+          final func = _findFunction(firebase, 'stream-stream-error-function')!;
+          final request = createCallableRequest(
+            headers: {'accept': 'text/event-stream'},
+          );
+          final response = await func.handler(request);
+
+          expect(response.statusCode, 200);
+          final body = await response.readAsString();
+          expect(body, contains('"result":"part 1"'));
+          expect(body, contains('"status":"INVALID_ARGUMENT"'));
+          expect(body, contains('"message":"Invalid part 2"'));
+        });
+
+        test(
+          'true background streaming works with Stream.fromIterable',
+          () async {
+            https.onCall(name: 'bgStreamFunction', (request, response) async {
+              final source = Stream.fromIterable([
+                CallableResult('item 1'),
+                CallableResult('item 2'),
+              ]);
+              response.stream(source);
+
+              return CallableResult('done');
+            });
+
+            final func = _findFunction(firebase, 'bg-stream-function')!;
+            final request = createCallableRequest(
+              headers: {'accept': 'text/event-stream'},
+            );
+            final response = await func.handler(request);
+
+            expect(response.statusCode, 200);
+
+            final body = await response.readAsString();
+            expect(body, contains('"result":"item 1"'));
+            expect(body, contains('"result":"item 2"'));
+            expect(body, contains('"result":"done"'));
+          },
+        );
       });
     });
 

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -290,9 +290,10 @@ void main() {
           expect(response.headers['content-type'], 'text/event-stream');
 
           final body = await response.readAsString();
-          expect(body, startsWith('data: {'));
-          expect(body, contains('"status":"INVALID_ARGUMENT"'));
-          expect(body, contains('"message":"Invalid data"'));
+          final jsonStr = body.substring('data: '.length).trim();
+          expect(jsonDecode(jsonStr), {
+            'error': {'status': 'INVALID_ARGUMENT', 'message': 'Invalid data'},
+          });
         });
 
         test(
@@ -315,9 +316,13 @@ void main() {
             expect(response.headers['content-type'], 'text/event-stream');
 
             final body = await response.readAsString();
-            expect(body, startsWith('data: {'));
-            expect(body, contains('"status":"INTERNAL"'));
-            expect(body, contains('"message":"An unexpected error occurred."'));
+            final jsonStr = body.substring('data: '.length).trim();
+            expect(jsonDecode(jsonStr), {
+              'error': {
+                'status': 'INTERNAL',
+                'message': 'An unexpected error occurred.',
+              },
+            });
           },
         );
 
@@ -339,8 +344,8 @@ void main() {
           expect(response.headers['content-type'], 'text/event-stream');
 
           final body = await response.readAsString();
-          expect(body, startsWith('data: {'));
-          expect(body, contains('"result":"success"'));
+          final jsonStr = body.substring('data: '.length).trim();
+          expect(jsonDecode(jsonStr), {'result': 'success'});
         });
 
         test('catches error emitted by stream and returns SSE error', () async {
@@ -367,9 +372,26 @@ void main() {
 
           expect(response.statusCode, 200);
           final body = await response.readAsString();
-          expect(body, contains('"result":"part 1"'));
-          expect(body, contains('"status":"INVALID_ARGUMENT"'));
-          expect(body, contains('"message":"Invalid part 2"'));
+          final events = body
+              .split('\n\n')
+              .where((e) => e.trim().isNotEmpty)
+              .toList();
+          expect(events.length, 2);
+          final decodedEvents = events
+              .map((e) => jsonDecode(e.substring('data: '.length)))
+              .toList();
+          expect(decodedEvents, contains(equals({'result': 'part 1'})));
+          expect(
+            decodedEvents,
+            contains(
+              equals({
+                'error': {
+                  'status': 'INVALID_ARGUMENT',
+                  'message': 'Invalid part 2',
+                },
+              }),
+            ),
+          );
         });
 
         test(
@@ -394,9 +416,17 @@ void main() {
             expect(response.statusCode, 200);
 
             final body = await response.readAsString();
-            expect(body, contains('"result":"item 1"'));
-            expect(body, contains('"result":"item 2"'));
-            expect(body, contains('"result":"done"'));
+            final events = body
+                .split('\n\n')
+                .where((e) => e.trim().isNotEmpty)
+                .toList();
+            expect(events.length, 3);
+            final decodedEvents = events
+                .map((e) => jsonDecode(e.substring('data: '.length)))
+                .toList();
+            expect(decodedEvents, contains(equals({'result': 'item 1'})));
+            expect(decodedEvents, contains(equals({'result': 'item 2'})));
+            expect(decodedEvents, contains(equals({'result': 'done'})));
           },
         );
       });

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -380,7 +380,7 @@ void main() {
           final decodedEvents = events
               .map((e) => jsonDecode(e.substring('data: '.length)))
               .toList();
-          expect(decodedEvents, contains(equals({'result': 'part 1'})));
+          expect(decodedEvents, contains(equals({'message': 'part 1'})));
           expect(
             decodedEvents,
             contains(
@@ -424,8 +424,8 @@ void main() {
             final decodedEvents = events
                 .map((e) => jsonDecode(e.substring('data: '.length)))
                 .toList();
-            expect(decodedEvents, contains(equals({'result': 'item 1'})));
-            expect(decodedEvents, contains(equals({'result': 'item 2'})));
+            expect(decodedEvents, contains(equals({'message': 'item 1'})));
+            expect(decodedEvents, contains(equals({'message': 'item 2'})));
             expect(decodedEvents, contains(equals({'result': 'done'})));
           },
         );


### PR DESCRIPTION
The previous implementation was broken in two ways:
1. CallableResponse used StreamController<String>, but Shelf Response expects bytes (List<int>), causing runtime type cast errors.
2. HttpsNamespace was awaiting closeStream() before returning the response, causing deadlocks.

Changes:
- Refactored CallableResponse to StreamController<List<int>>.
- Used json.fuse(utf8).encode for direct byte encoding.
- Switched to unawaited(closeStream()) in HttpsNamespace.
- Ported and adapted unit tests for HttpsError compatibility.
