### PR TITLE
fix: remove firestoreAdmin field from Firebase class

### DIFF
--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -37,20 +37,6 @@ import 'test_lab/test_lab_namespace.dart';
 ///
 /// Provides access to all function namespaces (https, pubsub, firestore, etc.).
 class Firebase {
-  factory Firebase() {
-    final env = FirebaseEnv();
-
-    // Initialize Admin SDK
-    final adminApp = FirebaseApp.initializeApp(
-      options: AppOptions(
-        credential: Credential.fromApplicationDefaultCredentials(),
-        projectId: env.projectId,
-      ),
-    );
-
-    return Firebase._(adminApp: adminApp, env: env);
-  }
-
   Firebase._({required this.adminApp, required FirebaseEnv env}) : _env = env;
 
   final FirebaseEnv _env;
@@ -244,4 +230,19 @@ abstract class FunctionsNamespace {
 @internal
 extension FirebaseInternal on Firebase {
   FirebaseEnv get $env => _env;
+}
+
+@internal
+Firebase createFirebaseInternal() {
+  final env = FirebaseEnv();
+
+  // Initialize Admin SDK
+  final adminApp = FirebaseApp.initializeApp(
+    options: AppOptions(
+      credential: Credential.fromApplicationDefaultCredentials(),
+      projectId: env.projectId,
+    ),
+  );
+
+  return Firebase._(adminApp: adminApp, env: env);
 }

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -15,7 +15,6 @@
 import 'dart:async';
 
 import 'package:dart_firebase_admin/dart_firebase_admin.dart';
-import 'package:google_cloud_firestore/google_cloud_firestore.dart' as gfs;
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -49,18 +48,10 @@ class Firebase {
       ),
     );
 
-    return Firebase._(
-      adminApp: adminApp,
-      firestoreAdmin: adminApp.firestore(),
-      env: env,
-    );
+    return Firebase._(adminApp: adminApp, env: env);
   }
 
-  Firebase._({
-    required this.adminApp,
-    required this.firestoreAdmin,
-    required FirebaseEnv env,
-  }) : _env = env;
+  Firebase._({required this.adminApp, required FirebaseEnv env}) : _env = env;
 
   final FirebaseEnv _env;
 
@@ -69,11 +60,6 @@ class Firebase {
   /// This app represents the server-side SDK and has elevated privileges
   /// corresponding to the environment's credentials.
   final FirebaseApp adminApp;
-
-  /// The Firestore admin client instance.
-  ///
-  /// Provides elevated server-side access to the Firestore database.
-  final gfs.Firestore firestoreAdmin;
 
   /// HTTPS triggers namespace.
   HttpsNamespace get https => HttpsNamespace(this);

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -46,7 +46,7 @@ typedef FunctionsRunner = FutureOr<void> Function(Firebase firebase);
 /// }
 /// ```
 Future<void> fireUp(List<String> args, FunctionsRunner runner) async {
-  final firebase = Firebase();
+  final firebase = createFirebaseInternal();
   final env = firebase.$env;
   final projectId = env.projectId;
 

--- a/test/unit/error_logging_test.dart
+++ b/test/unit/error_logging_test.dart
@@ -97,7 +97,7 @@ void main() {
     late HttpsNamespace https;
 
     setUp(() {
-      firebase = Firebase();
+      firebase = createFirebaseInternal();
       https = HttpsNamespace(firebase);
     });
 
@@ -156,7 +156,7 @@ void main() {
     late Firebase firebase;
 
     setUp(() {
-      firebase = Firebase();
+      firebase = createFirebaseInternal();
     });
 
     test('PubSub: unexpected error returns 500 without details', () async {

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -44,7 +44,7 @@ void main() {
     late HttpsNamespace https;
 
     setUp(() {
-      firebase = Firebase();
+      firebase = createFirebaseInternal();
       https = HttpsNamespace(firebase);
     });
 

--- a/test/unit/remote_config_test.dart
+++ b/test/unit/remote_config_test.dart
@@ -81,7 +81,7 @@ void main() {
     late RemoteConfigNamespace remoteConfig;
 
     setUp(() {
-      firebase = Firebase();
+      firebase = createFirebaseInternal();
       remoteConfig = RemoteConfigNamespace(firebase);
     });
 

--- a/test/unit/scheduler_namespace_test.dart
+++ b/test/unit/scheduler_namespace_test.dart
@@ -40,7 +40,7 @@ void main() {
     late SchedulerNamespace scheduler;
 
     setUp(() {
-      firebase = Firebase();
+      firebase = createFirebaseInternal();
       scheduler = SchedulerNamespace(firebase);
     });
 

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -82,7 +82,7 @@ void main() {
     late StorageNamespace storage;
 
     setUp(() {
-      firebase = Firebase();
+      firebase = createFirebaseInternal();
       storage = StorageNamespace(firebase);
     });
 


### PR DESCRIPTION
This is an unusual way to expose the default database

Also removed the public `Firestore` constructor.
