### PR TITLE
fix: support cross-file and variable reference options resolution

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -51,31 +51,33 @@ class _SpecBuilder implements Builder {
     final allParams = <String, ParamSpec>{};
     final allEndpoints = <String, EndpointSpec>{};
 
-    // Process each Dart file
-    for (final asset in assets) {
-      // Only process files in this package
-      if (asset.package != buildStep.inputId.package) continue;
+    // Pass 1: collect all top-level options variable declarations across every
+    // file into a shared map, and cache each parsed AST for reuse in pass 2.
+    // This enables cross-file resolution — e.g. options declared in
+    // shared_options.dart can be referenced in server.dart.
+    final sharedOptionsVars = <String, InstanceCreationExpression>{};
+    final astCache = <AssetId, CompilationUnit>{};
 
-      // Try to get the library (skip part files)
+    for (final asset in assets) {
+      if (asset.package != buildStep.inputId.package) continue;
       LibraryElement library;
       try {
         library = await resolver.libraryFor(asset, allowSyntaxErrors: true);
       } catch (e) {
-        // Likely a part file, skip it
         continue;
       }
-
-      // Get the resolved AST for this library using the first fragment
-      // We need resolved types for TypeChecker to work properly
       final fragment = library.firstFragment;
-      final ast = await resolver.astNodeFor(fragment, resolve: true);
-      if (ast == null) continue;
+      final astNode = await resolver.astNodeFor(fragment, resolve: true);
+      if (astNode is! CompilationUnit) continue;
+      astCache[asset] = astNode;
+      astNode.accept(_OptionsVariableCollector(sharedOptionsVars));
+    }
 
-      // Visit the AST to find function declarations
-      final visitor = _FirebaseFunctionsVisitor();
-      ast.accept(visitor);
-
-      // Collect discovered functions and parameters
+    // Pass 2: visit each file with the shared options map so that variable
+    // references to options declared in other files can be resolved.
+    for (final entry in astCache.entries) {
+      final visitor = _FirebaseFunctionsVisitor(sharedOptionsVars);
+      entry.value.accept(visitor);
       allParams.addAll(visitor.params);
       allEndpoints.addAll(visitor.endpoints);
     }
@@ -109,9 +111,34 @@ class _Namespace {
   bool matches(String methodName) => methodNames.contains(methodName);
 }
 
+/// Lightweight AST visitor that collects top-level variable declarations whose
+/// initializers are [InstanceCreationExpression]s into [variableToOptionsExpr].
+/// Used in a pre-pass over all files to enable cross-file options resolution.
+class _OptionsVariableCollector extends RecursiveAstVisitor<void> {
+  _OptionsVariableCollector(this.variableToOptionsExpr);
+
+  final Map<String, InstanceCreationExpression> variableToOptionsExpr;
+
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    for (final variable in node.variables.variables) {
+      final initializer = variable.initializer;
+      if (initializer is InstanceCreationExpression) {
+        variableToOptionsExpr[variable.name.lexeme] = initializer;
+      }
+    }
+    super.visitTopLevelVariableDeclaration(node);
+  }
+}
+
 /// AST visitor that discovers Firebase Functions declarations.
 class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
-  _FirebaseFunctionsVisitor() {
+  _FirebaseFunctionsVisitor([
+    Map<String, InstanceCreationExpression>? sharedOptionsVars,
+  ]) {
+    if (sharedOptionsVars != null) {
+      _variableToOptionsExpr.addAll(sharedOptionsVars);
+    }
     namespaces = <_Namespace>[
       _Namespace(
         _extractHttpsFunction,

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -756,9 +756,8 @@ void main(List<String> args) async {
       (request) async => Response.ok('Options via local variable'),
     );
 
-    // Options declared in a separate file — the builder cannot resolve these
-    // because _variableToOptionsExpr is scoped per-file. This function will
-    // fall back to the default region (us-central1).
+    // Options declared in a separate file — the builder can now resolve these
+    // using the shared options map collected in the first pass.
     firebase.https.onRequest(
       name: 'httpsCrossFileOptions',
       options: crossFileOpts,

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -15,6 +15,7 @@
 // ignore_for_file: experimental_member_use
 
 import 'package:firebase_functions/firebase_functions.dart';
+import 'shared_options.dart';
 
 // =============================================================================
 // Parameterized Configuration Examples
@@ -753,6 +754,15 @@ void main(List<String> args) async {
       name: 'httpsLocalVarOptions',
       options: localOpts,
       (request) async => Response.ok('Options via local variable'),
+    );
+
+    // Options declared in a separate file — the builder cannot resolve these
+    // because _variableToOptionsExpr is scoped per-file. This function will
+    // fall back to the default region (us-central1).
+    firebase.https.onRequest(
+      name: 'httpsCrossFileOptions',
+      options: crossFileOpts,
+      (request) async => Response.ok('Cross-file options'),
     );
 
     print('Functions registered successfully!');

--- a/test/fixtures/dart_reference/bin/shared_options.dart
+++ b/test/fixtures/dart_reference/bin/shared_options.dart
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:firebase_functions/firebase_functions.dart';
+
+/// Options declared in a separate file to test cross-file variable resolution.
+/// The builder visits each file independently, so variables declared here
+/// will NOT be resolved when referenced in server.dart — the function will
+/// fall back to the default region (us-central1).
+const crossFileOpts = HttpsOptions(
+  region: Region(SupportedRegion.europeWest2),
+  memory: Memory(MemoryOption.mb512),
+);

--- a/test/fixtures/dart_reference/bin/shared_options.dart
+++ b/test/fixtures/dart_reference/bin/shared_options.dart
@@ -15,9 +15,9 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 /// Options declared in a separate file to test cross-file variable resolution.
-/// The builder visits each file independently, so variables declared here
-/// will NOT be resolved when referenced in server.dart — the function will
-/// fall back to the default region (us-central1).
+/// Options declared in a separate file to test cross-file variable resolution.
+/// The builder now performs a pre-pass to collect these variables, allowing
+/// them to be resolved when referenced in other files like server.dart.
 const crossFileOpts = HttpsOptions(
   region: Region(SupportedRegion.europeWest2),
   memory: Memory(MemoryOption.mb512),

--- a/test/fixtures/nodejs_reference/index.js
+++ b/test/fixtures/nodejs_reference/index.js
@@ -673,6 +673,18 @@ exports.httpsLocalVarOptions = onRequest(
   }
 );
 
+// Options declared in a separate file (cross-file reference)
+const crossFileOpts = {
+  region: "europe-west2",
+  memory: "512MiB",
+};
+exports.httpsCrossFileOptions = onRequest(
+  crossFileOpts,
+  (request, response) => {
+    response.send("Cross-file options");
+  }
+);
+
 // Task queue function with options
 exports.sendEmail = onTaskDispatched(
   {

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -320,14 +320,14 @@ void main() {
 
       expect(
         dartEndpoints.keys.length,
-        equals(50),
+        equals(51),
         reason:
-            'Should discover 50 functions (5 Callable + 4 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options)',
+            'Should discover 51 functions (5 Callable + 4 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
       );
       expect(
         nodejsEndpoints.keys.length,
-        equals(50),
-        reason: 'Node.js reference should also have 50 endpoints',
+        equals(51),
+        reason: 'Node.js reference should also have 51 endpoints',
       );
 
       // Verify both manifests have the same endpoints (normalized via
@@ -1913,6 +1913,19 @@ void main() {
 
       expect(dartFunc['availableMemoryMb'], equals(2048));
       expect(nodejsFunc['availableMemoryMb'], equals(2048));
+    });
+
+    test('should resolve options from cross-file variable reference', () {
+      final dartFunc = _getEndpoint(dartManifest, 'httpsCrossFileOptions')!;
+      final nodejsFunc = _getEndpoint(nodejsManifest, 'httpsCrossFileOptions')!;
+
+      final dartRegion = dartFunc['region'] as List;
+      final nodejsRegion = nodejsFunc['region'] as List;
+      expect(dartRegion, contains('europe-west2'));
+      expect(nodejsRegion, contains('europe-west2'));
+
+      expect(dartFunc['availableMemoryMb'], equals(512));
+      expect(nodejsFunc['availableMemoryMb'], equals(512));
     });
   });
 }


### PR DESCRIPTION
Adds cross-file options resolution — variables declared in a separate file (e.g. shared_options.dart) are now correctly resolved when referenced in another file.