### PR TITLE
doc(README): provide links to firebase docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add a comment to the generated manifest (`functions.yaml`) to indicate that
   it is managed by this package.
+- Add "Learn more" and "Usage" sections to README.md.
 
 ## 0.5.1
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,42 @@
+# Dart Firebase SDK for Cloud Functions
+
 [![Tests](https://github.com/firebase/firebase-functions-dart/actions/workflows/test.yml/badge.svg)](https://github.com/firebase/firebase-functions-dart/actions/workflows/test.yml)
-[![pub package](https://img.shields.io/pub/v/firebase_functions.svg)](https://pub.dev/packages/firebase_functions) 
+[![pub package](https://img.shields.io/pub/v/firebase_functions.svg)](https://pub.dev/packages/firebase_functions)
 
-Write Firebase Cloud Functions in Dart with full type safety and performance.
+The `firebase_functions` package provides an SDK for defining Cloud Functions for Firebase in Dart.
 
-[Quickstart](https://firebase.google.com/docs/functions/start-dart)
-[Read the full API reference](https://pub.dev/documentation/firebase_functions/latest/)
-[Browse some examples](example/)
-[Codelabs](https://codelabs.developers.google.com/deploy-dart-on-firebase-functions)
+Cloud Functions is a hosted, private, and scalable environment where you can run code. The Firebase SDK for Cloud Functions integrates the Firebase platform by letting you write code that responds to events and invokes functionality exposed by other Firebase features.
+
+## Learn more
+
+Learn more about the Firebase SDK for Cloud Functions in the [Firebase documentation](https://firebase.google.com/docs/functions/) or [check out our samples](example/).
+
+Here are some resources to get help:
+
+- [Start with the quickstart](https://firebase.google.com/docs/functions/start-dart)
+- [Go through the guides](https://firebase.google.com/docs/functions/)
+- [Read the full API reference](https://pub.dev/documentation/firebase_functions/latest/)
+- [Browse some examples](example/)
+- [Codelabs](https://codelabs.developers.google.com/deploy-dart-on-firebase-functions)
+
+If the official documentation doesn't help, try asking through our [official support channels](https://firebase.google.com/support/)
+
+## Usage
+
+```dart
+import 'package:firebase_functions/firebase_functions.dart';
+
+void main(List<String> args) {
+  fireUp(args, (firebase) {
+    firebase.https.onRequest(
+      name: 'hello',
+      (request) async {
+        return Response.ok('Hello from Dart!');
+      },
+    );
+  });
+}
+```
 
 ## Status: Experimental (v0.5.0)
 
@@ -39,7 +69,7 @@ This package provides a Dart implementation of Firebase Cloud Functions. Only HT
 ## Table of Contents
 
 - [Features](#features)
-- [Quick Start](#quick-start)
+- [Usage](#usage)
   - [HTTPS Functions](#https-functions)
   - [Pub/Sub Triggers](#pubsub-triggers)
   - [Firestore Triggers](#firestore-triggers)
@@ -66,17 +96,7 @@ This package provides a Dart implementation of Firebase Cloud Functions. Only HT
 - **Error Handling**: Built-in typed error classes matching the Node.js SDK
 - **Hot Reload**: Fast development with build_runner watch
 
-## Quick Start
 
-```dart
-import 'package:firebase_functions/firebase_functions.dart';
-
-void main(List<String> args) {
-  fireUp(args, (firebase) {
-    // Register your functions here
-  });
-}
-```
 
 ## HTTPS Functions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Dart Firebase SDK for Cloud Functions
 
+<!--
+Keep this content in sync with the Node and Python READMEs:
+  - https://github.com/firebase/firebase-functions
+  - https://github.com/firebase/firebase-functions-python
+-->
+
 [![Tests](https://github.com/firebase/firebase-functions-dart/actions/workflows/test.yml/badge.svg)](https://github.com/firebase/firebase-functions-dart/actions/workflows/test.yml)
 [![pub package](https://img.shields.io/pub/v/firebase_functions.svg)](https://pub.dev/packages/firebase_functions)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here are some resources to get help:
 - [Browse some examples](example/)
 - [Codelabs](https://codelabs.developers.google.com/deploy-dart-on-firebase-functions)
 
-If the official documentation doesn't help, try asking through our [official support channels](https://firebase.google.com/support/)
+If the official documentation doesn't help, try asking through our [official support channels](https://firebase.google.com/support/).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 Write Firebase Cloud Functions in Dart with full type safety and performance.
 
+[Quickstart](https://firebase.google.com/docs/functions/start-dart)
+[Read the full API reference](https://pub.dev/documentation/firebase_functions/latest/)
+[Browse some examples](example/)
+[Codelabs](https://codelabs.developers.google.com/deploy-dart-on-firebase-functions)
+
 ## Status: Experimental (v0.5.0)
 
 This package provides a Dart implementation of Firebase Cloud Functions. Only HTTPS triggers are currently supported in production. Other trigger types are experimental and have varying levels of support.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ This package provides a Dart implementation of Firebase Cloud Functions. Only HT
 - **Error Handling**: Built-in typed error classes matching the Node.js SDK
 - **Hot Reload**: Fast development with build_runner watch
 
-
-
 ## HTTPS Functions
 
 ### onRequest - Raw HTTP Handler


### PR DESCRIPTION
Structure the introduction of the README.md like the [Python](https://pypi.org/project/firebase-functions/) and [Node](https://github.com/firebase/firebase-functions/blob/master/README.md) READMEs.

Adds "Learn more" and "Usage" sections.

Fixes https://github.com/firebase/firebase-functions-dart/issues/129
