### PR TITLE
Rename fireUp to runFunctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0-wip
+
+- Add `runFunctions` as the primary API.
+- Deprecate `fireUp` in favor of `runFunctions`.
+
 ## 0.5.2
 
 - Add a comment to the generated manifest (`functions.yaml`) to indicate that

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If the official documentation doesn't help, try asking through our [official sup
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) {
-  fireUp(args, (firebase) {
+  runFunctions((firebase) {
     firebase.https.onRequest(
       name: 'hello',
       (request) async {

--- a/example/alerts/bin/server.dart
+++ b/example/alerts/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // App Distribution new tester iOS device alert
     firebase.alerts.appDistribution.onNewTesterIosDevicePublished((
       event,

--- a/example/alerts/pubspec.yaml
+++ b/example/alerts/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/auth/bin/server.dart
+++ b/example/auth/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Before user created - runs before a new user is created
     firebase.identity.beforeUserCreated(
       options: const BlockingOptions(idToken: true, accessToken: true),

--- a/example/auth/pubspec.yaml
+++ b/example/auth/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/database/bin/server.dart
+++ b/example/database/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Database onValueCreated - triggers when data is created
     firebase.database.onValueCreated(ref: 'messages/{messageId}', (
       event,

--- a/example/database/pubspec.yaml
+++ b/example/database/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/eventarc/bin/server.dart
+++ b/example/eventarc/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Basic Eventarc custom event - uses default Firebase channel
     firebase.eventarc.onCustomEventPublished(eventType: 'com.example.myevent', (
       event,

--- a/example/eventarc/pubspec.yaml
+++ b/example/eventarc/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/firestore/bin/server.dart
+++ b/example/firestore/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Firestore onDocumentCreated - triggers when a document is created
     firebase.firestore.onDocumentCreated(document: 'users/{userId}', (
       event,

--- a/example/firestore/pubspec.yaml
+++ b/example/firestore/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/firestore_test/bin/server.dart
+++ b/example/firestore_test/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Test Firestore onDocumentCreated with wildcard
     firebase.firestore.onDocumentCreated(document: 'users/{userId}', (
       event,

--- a/example/firestore_test/pubspec.yaml
+++ b/example/firestore_test/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/https/bin/server.dart
+++ b/example/https/bin/server.dart
@@ -43,7 +43,7 @@ final isProduction = defineBoolean(
 );
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Basic callable function - untyped data
     firebase.https.onCall(name: 'greet', (request, response) async {
       final data = request.data as Map<String, dynamic>?;

--- a/example/https/pubspec.yaml
+++ b/example/https/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/pubsub/bin/server.dart
+++ b/example/pubsub/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Pub/Sub trigger - triggers when a message is published to a topic
     firebase.pubsub.onMessagePublished(topic: 'my-topic', (event) async {
       final message = event.data;

--- a/example/pubsub/pubspec.yaml
+++ b/example/pubsub/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/remoteconfig/bin/server.dart
+++ b/example/remoteconfig/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Remote Config update trigger
     firebase.remoteConfig.onConfigUpdated((event) async {
       final data = event.data;

--- a/example/remoteconfig/pubspec.yaml
+++ b/example/remoteconfig/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/scheduler/bin/server.dart
+++ b/example/scheduler/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Basic scheduled function - runs every day at midnight
     firebase.scheduler.onSchedule(schedule: '0 0 * * *', (event) async {
       print('Scheduled function triggered:');

--- a/example/scheduler/pubspec.yaml
+++ b/example/scheduler/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/storage/bin/server.dart
+++ b/example/storage/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Storage onObjectFinalized - triggers when an object is created/overwritten
     firebase.storage.onObjectFinalized(
       bucket: 'demo-test.firebasestorage.app',

--- a/example/storage/pubspec.yaml
+++ b/example/storage/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/tasks/bin/server.dart
+++ b/example/tasks/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Basic task queue function
     firebase.tasks.onTaskDispatched(name: 'processOrder', (request) async {
       final data = request.data as Map<String, dynamic>;

--- a/example/tasks/pubspec.yaml
+++ b/example/tasks/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/testlab/bin/server.dart
+++ b/example/testlab/bin/server.dart
@@ -17,7 +17,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // Test Lab onTestMatrixCompleted - triggers when a test matrix completes
     firebase.testLab.onTestMatrixCompleted((event) async {
       final data = event.data;

--- a/example/testlab/pubspec.yaml
+++ b/example/testlab/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/lib/firebase_functions.dart
+++ b/lib/firebase_functions.dart
@@ -22,7 +22,7 @@
 /// import 'package:firebase_functions/firebase_functions.dart';
 ///
 /// void main(List<String> args) {
-///   fireUp(args, (firebase) {
+///   runFunctions((firebase) {
 ///     firebase.https.onRequest(
 ///       name: 'hello',
 ///       (request) async => Response.ok('Hello, World!'),
@@ -117,7 +117,7 @@ export 'src/remote_config/remote_config.dart';
 // Experimental: Scheduler triggers (not yet supported in production or emulator)
 export 'src/scheduler/scheduler.dart';
 // Core runtime
-export 'src/server.dart' show fireUp;
+export 'src/server.dart' show fireUp, runFunctions;
 // Experimental: Storage triggers (emulator only)
 export 'src/storage/storage.dart';
 // Experimental: Task queue triggers (not yet supported in production or emulator)

--- a/lib/src/common/on_init.dart
+++ b/lib/src/common/on_init.dart
@@ -46,7 +46,7 @@ bool _didInit = false;
 ///     apiClient = SomeApiClient(apiKey: apiKey.value());
 ///   });
 ///
-///   fireUp(args, (firebase) {
+///   runFunctions((firebase) {
 ///     firebase.https.onRequest(
 ///       name: 'api',
 ///       options: HttpsOptions(secrets: [apiKey]),

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -37,7 +37,7 @@ typedef FunctionsRunner = FutureOr<void> Function(Firebase firebase);
 /// Example:
 /// ```dart
 /// void main(List<String> args) {
-///   fireUp(args, (firebase) {
+///   runFunctions((firebase) {
 ///     firebase.https.onRequest(
 ///       name: 'hello',
 ///       (request) async => Response.ok('Hello!'),
@@ -45,7 +45,26 @@ typedef FunctionsRunner = FutureOr<void> Function(Firebase firebase);
 ///   });
 /// }
 /// ```
-Future<void> fireUp(List<String> args, FunctionsRunner runner) async {
+@Deprecated('Use `runFunctions` instead.')
+Future<void> fireUp(List<String> args, FunctionsRunner runner) =>
+    runFunctions(runner);
+
+/// Starts the Firebase Functions runtime.
+///
+/// This is the main entry point for a Firebase Functions application.
+///
+/// Example:
+/// ```dart
+/// void main(List<String> args) {
+///   runFunctions((firebase) {
+///     firebase.https.onRequest(
+///       name: 'hello',
+///       (request) async => Response.ok('Hello!'),
+///     );
+///   });
+/// }
+/// ```
+Future<void> runFunctions(FunctionsRunner runner) async {
   final firebase = createFirebaseInternal();
   final env = firebase.$env;
   final projectId = env.projectId;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,9 +14,9 @@
 
 name: firebase_functions
 description: >-
-  Cloud Functions for Dart with support for the Firebase Admin SDK, 
+  Cloud Functions for Dart with support for the Firebase Admin SDK,
   Cloud Storage and Firestore
-version: 0.5.2
+version: 0.6.0-wip
 repository: https://github.com/firebase/firebase-functions-dart
 
 environment:

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -50,7 +50,7 @@ final isProduction = defineBoolean(
 );
 
 void main(List<String> args) async {
-  await fireUp(args, (firebase) {
+  await runFunctions((firebase) {
     // ==========================================================================
     // HTTPS Callable Functions (onCall / onCallWithData)
     // ==========================================================================

--- a/test/fixtures/dart_reference/pubspec.yaml
+++ b/test/fixtures/dart_reference/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0-0
 
 dev_dependencies:
   build_runner: ^2.10.5


### PR DESCRIPTION
- Removed unused `args` param
- Deprecated fireUp for now

Fixes https://github.com/firebase/firebase-functions-dart/issues/155
