### PR TITLE
feat: add support for setGlobalOptions method

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -62,6 +62,30 @@ firebase.https.onRequest(
 );
 ```
 
+## Global Options
+
+Use `setGlobalOptions` to set defaults for every function. Per-function options
+override these defaults.
+
+```dart
+setGlobalOptions(
+  const GlobalOptions(
+    region: Region(SupportedRegion.europeWest1),
+    enforceAppCheck: EnforceAppCheck(true),
+  ),
+);
+
+firebase.https.onCall(name: 'secureCallable', (request, response) async {
+  return CallableResult({'ok': true});
+});
+
+firebase.https.onRequest(
+  name: 'usEndpoint',
+  options: const HttpsOptions(region: Region(SupportedRegion.usCentral1)),
+  (request) async => Response.ok('Runs in us-central1'),
+);
+```
+
 ## Firebase Admin SDK
 
 The Functions runtime uses a Firebase Admin SDK app for features such as

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -73,12 +73,11 @@ class _SpecBuilder implements Builder {
       astNode.accept(_OptionsVariableCollector(sharedOptionsVars));
     }
 
-    InstanceCreationExpression? globalOptions;
+    final globalOptionsCollector = _GlobalOptionsCollector(sharedOptionsVars);
     for (final ast in astCache.values) {
-      final collector = _GlobalOptionsCollector(sharedOptionsVars);
-      ast.accept(collector);
-      globalOptions = collector.globalOptions ?? globalOptions;
+      ast.accept(globalOptionsCollector);
     }
+    final globalOptions = globalOptionsCollector.globalOptions;
 
     // Pass 2: visit each file with the shared options map so that variable
     // references to options declared in other files can be resolved.

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -73,10 +73,20 @@ class _SpecBuilder implements Builder {
       astNode.accept(_OptionsVariableCollector(sharedOptionsVars));
     }
 
+    InstanceCreationExpression? globalOptions;
+    for (final ast in astCache.values) {
+      final collector = _GlobalOptionsCollector(sharedOptionsVars);
+      ast.accept(collector);
+      globalOptions = collector.globalOptions ?? globalOptions;
+    }
+
     // Pass 2: visit each file with the shared options map so that variable
     // references to options declared in other files can be resolved.
     for (final entry in astCache.entries) {
-      final visitor = _FirebaseFunctionsVisitor(sharedOptionsVars);
+      final visitor = _FirebaseFunctionsVisitor(
+        sharedOptionsVars,
+        globalOptions: globalOptions,
+      );
       entry.value.accept(visitor);
       allParams.addAll(visitor.params);
       allEndpoints.addAll(visitor.endpoints);
@@ -131,11 +141,33 @@ class _OptionsVariableCollector extends RecursiveAstVisitor<void> {
   }
 }
 
+/// Collects the expression passed to `setGlobalOptions(...)`.
+class _GlobalOptionsCollector extends RecursiveAstVisitor<void> {
+  _GlobalOptionsCollector(this.variableToOptionsExpr);
+
+  final Map<String, InstanceCreationExpression> variableToOptionsExpr;
+  InstanceCreationExpression? globalOptions;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.target == null && node.methodName.name == 'setGlobalOptions') {
+      final firstArg = node.argumentList.arguments.firstOrNull;
+      if (firstArg is InstanceCreationExpression) {
+        globalOptions = firstArg;
+      } else if (firstArg is SimpleIdentifier) {
+        globalOptions = variableToOptionsExpr[firstArg.name] ?? globalOptions;
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+}
+
 /// AST visitor that discovers Firebase Functions declarations.
 class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
-  _FirebaseFunctionsVisitor([
-    Map<String, InstanceCreationExpression>? sharedOptionsVars,
-  ]) {
+  _FirebaseFunctionsVisitor(
+    Map<String, InstanceCreationExpression>? sharedOptionsVars, {
+    InstanceCreationExpression? globalOptions,
+  }) : _globalOptionsExpr = globalOptions {
     if (sharedOptionsVars != null) {
       _variableToOptionsExpr.addAll(sharedOptionsVars);
     }
@@ -258,6 +290,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
   final Map<String, ParamSpec> params = {};
   final Map<String, EndpointSpec> endpoints = {};
   late final List<_Namespace> namespaces;
+  final InstanceCreationExpression? _globalOptionsExpr;
 
   /// Maps variable names to their actual parameter names.
   /// e.g., 'minInstances' -> 'MIN_INSTANCES'
@@ -426,6 +459,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     endpoints[functionName] = EndpointSpec(
       name: functionName,
       type: triggerType,
+      globalOptions: _globalOptionsExpr,
       options: node.findOptionsArg(_variableToOptionsExpr),
       variableToParamName: _variableToParamName,
     );
@@ -445,6 +479,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       name: functionName,
       type: 'pubsub',
       topic: topicName, // Keep original topic name for eventFilters
+      globalOptions: _globalOptionsExpr,
       options: node.findOptionsArg(_variableToOptionsExpr),
       variableToParamName: _variableToParamName,
     );
@@ -482,6 +517,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       documentPath: documentPath,
       database: database ?? '(default)',
       namespace: namespace ?? '(default)',
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -517,6 +553,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       databaseEventType: methodName,
       refPath: refPath,
       instance: instance ?? '*',
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -550,6 +587,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       type: 'alert',
       alertType: alertTypeValue,
       appId: appId,
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -629,6 +667,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     endpoints[functionName] = EndpointSpec(
       name: functionName,
       type: 'remoteConfig',
+      globalOptions: _globalOptionsExpr,
       options: node.findOptionsArg(_variableToOptionsExpr),
       variableToParamName: _variableToParamName,
     );
@@ -649,6 +688,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       type: 'storage',
       storageBucket: bucketName,
       storageEventType: methodName,
+      globalOptions: _globalOptionsExpr,
       options: node.findOptionsArg(_variableToOptionsExpr),
       variableToParamName: _variableToParamName,
     );
@@ -675,6 +715,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       type: 'alert',
       alertType: alertType,
       appId: appId,
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -715,6 +756,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       idToken: idToken,
       accessToken: accessToken,
       refreshToken: refreshToken,
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -754,6 +796,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       schedule: schedule,
       timeZone: timeZone,
       retryConfig: retryConfig,
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -780,6 +823,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       type: 'taskQueue',
       taskQueueRetryConfig: retryConfig,
       taskQueueRateLimits: rateLimits,
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -811,6 +855,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
       eventarcEventType: eventType,
       eventarcChannel: channel ?? 'locations/us-central1/channels/firebase',
       eventarcFilters: filters,
+      globalOptions: _globalOptionsExpr,
       options: optionsArg,
       variableToParamName: _variableToParamName,
     );
@@ -825,6 +870,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     endpoints[functionName] = EndpointSpec(
       name: functionName,
       type: 'testLab',
+      globalOptions: _globalOptionsExpr,
       options: node.findOptionsArg(_variableToOptionsExpr),
       variableToParamName: _variableToParamName,
     );

--- a/lib/src/builder/spec.dart
+++ b/lib/src/builder/spec.dart
@@ -71,6 +71,7 @@ class EndpointSpec {
     this.eventarcEventType,
     this.eventarcChannel,
     this.eventarcFilters,
+    this.globalOptions,
     this.options,
     this.variableToParamName = const {},
   });
@@ -102,16 +103,34 @@ class EndpointSpec {
   final String? eventarcEventType; // For Eventarc: custom event type
   final String? eventarcChannel; // For Eventarc: channel ID
   final Map<String, String>? eventarcFilters; // For Eventarc: event filters
+  final InstanceCreationExpression? globalOptions;
   final InstanceCreationExpression? options;
   final Map<String, String> variableToParamName;
 
   /// Extracts options configuration from the AST.
   Map<String, dynamic> extractOptions() {
+    final result = _extractOptions(globalOptions);
+    final endpointOptions = _extractOptions(options);
+
+    for (final entry in endpointOptions.entries) {
+      if (identical(entry.value, _resetOption)) {
+        result.remove(entry.key);
+      } else {
+        result[entry.key] = entry.value;
+      }
+    }
+
+    return result;
+  }
+
+  static const Object _resetOption = Object();
+
+  Map<String, dynamic> _extractOptions(InstanceCreationExpression? options) {
     if (options == null) return {};
 
     final result = <String, dynamic>{};
 
-    for (final arg in options!.argumentList.arguments) {
+    for (final arg in options.argumentList.arguments) {
       if (arg is! NamedExpression) continue;
 
       final name = arg.name.label.name;
@@ -119,7 +138,7 @@ class EndpointSpec {
 
       // Helper to reduce boilerplate: only adds to map if value exists
       void add(String key, dynamic Function(Expression expr) func) {
-        final value = func(expr);
+        final value = _isResetOption(expr) ? _resetOption : func(expr);
         if (value != null) result[key] = value;
       }
 
@@ -128,6 +147,9 @@ class EndpointSpec {
           add('availableMemoryMb', _extractMemory);
         case 'cpu':
           add('cpu', _extractCpu);
+        case 'enforceAppCheck':
+          // Runtime-only option for callable functions.
+          break;
         case 'timeoutSeconds':
           add('timeoutSeconds', _extractTimeoutSeconds);
         case 'minInstances':
@@ -162,7 +184,6 @@ class EndpointSpec {
         // - heartBeatIntervalSeconds: Runtime streaming keepalive
         // - preserveExternalChanges: Deployment behavior, not function config
         case 'cors':
-        case 'enforceAppCheck':
         case 'preserveExternalChanges':
         case 'consumeAppCheckToken':
         case 'heartBeatIntervalSeconds':
@@ -173,6 +194,11 @@ class EndpointSpec {
 
     return result;
   }
+
+  bool _isResetOption(Expression expression) =>
+      expression is InstanceCreationExpression &&
+      (expression.constructorName.name?.name == 'reset' ||
+          expression.constructorName.toSource().endsWith('.reset'));
 
   /// Extracts Memory option value.
   Object? _extractMemory(Expression expression) {

--- a/lib/src/builder/spec.dart
+++ b/lib/src/builder/spec.dart
@@ -120,7 +120,7 @@ class EndpointSpec {
       }
     }
 
-    return result;
+    return result..removeWhere((_, value) => identical(value, _resetOption));
   }
 
   static const Object _resetOption = Object();
@@ -197,6 +197,8 @@ class EndpointSpec {
 
   bool _isResetOption(Expression expression) =>
       expression is InstanceCreationExpression &&
+      // `name` is preferred, but resolved/synthetic ASTs can represent
+      // typedef-backed constructors without it.
       (expression.constructorName.name?.name == 'reset' ||
           expression.constructorName.toSource().endsWith('.reset'));
 

--- a/lib/src/common/options.dart
+++ b/lib/src/common/options.dart
@@ -15,6 +15,22 @@
 import 'expression.dart';
 import 'params.dart';
 
+GlobalOptions _globalOptions = const GlobalOptions();
+
+/// Sets default options applied to all subsequently declared functions.
+///
+/// Per-function options override these defaults. For callable functions,
+/// [GlobalOptions.enforceAppCheck] is also used at runtime unless overridden by
+/// the callable's own options.
+void setGlobalOptions(GlobalOptions options) {
+  _globalOptions = options;
+}
+
+/// Gets the current default options.
+///
+/// This is used internally by trigger registration.
+GlobalOptions getGlobalOptions() => _globalOptions;
+
 /// Global options that apply to all function types.
 ///
 /// Matches the GlobalOptions interface from the Node.js SDK.
@@ -22,6 +38,7 @@ class GlobalOptions {
   const GlobalOptions({
     this.concurrency,
     this.cpu,
+    this.enforceAppCheck,
     this.ingressSettings,
     this.invoker,
     this.labels,
@@ -43,6 +60,9 @@ class GlobalOptions {
 
   /// Amount of CPU to allocate to the function.
   final Cpu? cpu;
+
+  /// Whether to enforce Firebase App Check for callable functions.
+  final EnforceAppCheck? enforceAppCheck;
 
   /// Ingress settings controlling who can call the function.
   final Ingress? ingressSettings;

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -18,6 +18,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
+import '../common/options.dart';
 import '../common/utilities.dart';
 import '../firebase.dart';
 import 'auth.dart';
@@ -119,7 +120,10 @@ class HttpsNamespace extends FunctionsNamespace {
       }
 
       // Check for invalid or missing app check token if enforced
-      final enforceAppCheck = options?.enforceAppCheck?.runtimeValue() ?? false;
+      final enforceAppCheck =
+          options?.enforceAppCheck?.runtimeValue() ??
+          getGlobalOptions().enforceAppCheck?.runtimeValue() ??
+          false;
       if (tokens.result.app == TokenStatus.invalid) {
         if (enforceAppCheck) {
           return UnauthenticatedError().toShelfResponse();
@@ -200,7 +204,10 @@ class HttpsNamespace extends FunctionsNamespace {
       }
 
       // Check for invalid or missing app check token if enforced
-      final enforceAppCheck = options?.enforceAppCheck?.runtimeValue() ?? false;
+      final enforceAppCheck =
+          options?.enforceAppCheck?.runtimeValue() ??
+          getGlobalOptions().enforceAppCheck?.runtimeValue() ??
+          false;
       if (tokens.result.app == TokenStatus.invalid) {
         if (enforceAppCheck) {
           return UnauthenticatedError().toShelfResponse();

--- a/lib/src/https/options.dart
+++ b/lib/src/https/options.dart
@@ -19,6 +19,7 @@ class HttpsOptions extends GlobalOptions {
   const HttpsOptions({
     super.concurrency,
     super.cpu,
+    super.enforceAppCheck,
     super.ingressSettings,
     super.invoker,
     super.labels,
@@ -45,6 +46,7 @@ class CallableOptions extends HttpsOptions {
   const CallableOptions({
     super.concurrency,
     super.cpu,
+    super.enforceAppCheck,
     super.ingressSettings,
     super.invoker,
     super.labels,
@@ -61,15 +63,11 @@ class CallableOptions extends HttpsOptions {
     super.vpcConnectorEgressSettings,
     super.cors,
     this.consumeAppCheckToken,
-    this.enforceAppCheck,
     this.heartBeatIntervalSeconds,
   });
 
   /// Whether to consume the App Check token.
   final ConsumeAppCheckToken? consumeAppCheckToken;
-
-  /// Whether to enforce App Check.
-  final EnforceAppCheck? enforceAppCheck;
 
   /// Heartbeat interval in seconds for streaming responses.
   final HeartBeatIntervalSeconds? heartBeatIntervalSeconds;

--- a/test/unit/global_options_test.dart
+++ b/test/unit/global_options_test.dart
@@ -57,6 +57,28 @@ final endpointOptions = new HttpsOptions(
       expect(endpoint['timeoutSeconds'], isNull);
       expect(endpoint['httpsTrigger'], equals({}));
     });
+
+    test('does not emit reset values from global options', () {
+      final globalOptions = _initializerFor('''
+final globalOptions = new GlobalOptions(
+  timeoutSeconds: new TimeoutSeconds.reset(),
+);
+''', 'globalOptions');
+
+      final yaml = generateManifestYaml({}, {
+        'globalResetEndpoint': EndpointSpec(
+          name: 'globalResetEndpoint',
+          type: 'https',
+          globalOptions: globalOptions,
+        ),
+      });
+      final manifest = loadYaml(yaml) as YamlMap;
+      final endpoint =
+          (manifest['endpoints'] as YamlMap)['global-reset-endpoint']
+              as YamlMap;
+
+      expect(endpoint['timeoutSeconds'], isNull);
+    });
   });
 }
 

--- a/test/unit/global_options_test.dart
+++ b/test/unit/global_options_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:firebase_functions/src/builder/manifest.dart';
+import 'package:firebase_functions/src/builder/spec.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('setGlobalOptions', () {
+    test('merges global defaults with endpoint options', () {
+      final globalOptions = _initializerFor('''
+final globalOptions = new GlobalOptions(
+  region: new Region(SupportedRegion.europeWest1),
+  memory: new Memory(MemoryOption.mb512),
+  timeoutSeconds: new TimeoutSeconds(120),
+  minInstances: new Instances(1),
+  enforceAppCheck: new EnforceAppCheck(true),
+);
+''', 'globalOptions');
+      final endpointOptions = _initializerFor('''
+final endpointOptions = new HttpsOptions(
+  region: new Region(SupportedRegion.usWest1),
+  memory: new Memory(MemoryOption.gb1),
+  timeoutSeconds: new TimeoutSeconds.reset(),
+);
+''', 'endpointOptions');
+
+      final yaml = generateManifestYaml({}, {
+        'globalEndpoint': EndpointSpec(
+          name: 'globalEndpoint',
+          type: 'https',
+          globalOptions: globalOptions,
+          options: endpointOptions,
+        ),
+      });
+      final manifest = loadYaml(yaml) as YamlMap;
+      final endpoint =
+          (manifest['endpoints'] as YamlMap)['global-endpoint'] as YamlMap;
+
+      expect(endpoint['region'], equals(['us-west1']));
+      expect(endpoint['availableMemoryMb'], equals(1024));
+      expect(endpoint['minInstances'], equals(1));
+      expect(endpoint['timeoutSeconds'], isNull);
+      expect(endpoint['httpsTrigger'], equals({}));
+    });
+  });
+}
+
+InstanceCreationExpression _initializerFor(String source, String name) {
+  final unit = parseString(content: source).unit;
+  for (final declaration in unit.declarations) {
+    if (declaration is! TopLevelVariableDeclaration) continue;
+    for (final variable in declaration.variables.variables) {
+      if (variable.name.lexeme == name) {
+        return variable.initializer! as InstanceCreationExpression;
+      }
+    }
+  }
+  throw StateError('No initializer found for $name');
+}


### PR DESCRIPTION
closes https://github.com/firebase/firebase-functions-dart/issues/149

Use `setGlobalOptions` to set defaults for every function. Per-function options
override these defaults.

```dart
setGlobalOptions(
  const GlobalOptions(
    region: Region(SupportedRegion.europeWest1),
    enforceAppCheck: EnforceAppCheck(true),
  ),
);

firebase.https.onCall(name: 'secureCallable', (request, response) async {
  return CallableResult({'ok': true});
});

firebase.https.onRequest(
  name: 'usEndpoint',
  options: const HttpsOptions(region: Region(SupportedRegion.usCentral1)),
  (request) async => Response.ok('Runs in us-central1'),
);
```
