### PR TITLE
fix: createCustomToken fails in emulator with default application credentials

### DIFF
--- a/lib/src/common/environment.dart
+++ b/lib/src/common/environment.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:google_cloud/constants.dart' as google_cloud;
 import 'package:meta/meta.dart';
 
 /// Provides unified access to environment variables, emulator checks, and
@@ -114,9 +115,7 @@ class FirebaseEnv {
 /// Common project ID environment variables checked in order.
 const _projectIdEnvKeyOptions = [
   'FIREBASE_PROJECT',
-  'GCLOUD_PROJECT',
-  'GOOGLE_CLOUD_PROJECT',
-  'GCP_PROJECT',
+  ...google_cloud.projectIdEnvironmentVariableOptions,
 ];
 
 /// Common emulator host keys used to detect emulator environment.

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -239,9 +239,7 @@ Firebase createFirebaseInternal() {
   // Initialize Admin SDK — credential is auto-discovered from the environment
   // via GOOGLE_APPLICATION_CREDENTIALS (service account) or ADC fallback.
   final adminApp = FirebaseApp.initializeApp(
-    options: AppOptions(
-      projectId: env.projectId,
-    ),
+    options: AppOptions(projectId: env.projectId),
   );
 
   return Firebase._(adminApp: adminApp, env: env);

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -236,10 +236,10 @@ extension FirebaseInternal on Firebase {
 Firebase createFirebaseInternal() {
   final env = FirebaseEnv();
 
-  // Initialize Admin SDK
+  // Initialize Admin SDK — credential is auto-discovered from the environment
+  // via GOOGLE_APPLICATION_CREDENTIALS (service account) or ADC fallback.
   final adminApp = FirebaseApp.initializeApp(
     options: AppOptions(
-      credential: Credential.fromApplicationDefaultCredentials(),
       projectId: env.projectId,
     ),
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   dart_jsonwebtoken: ^3.2.0
   firebase_admin_sdk: ^0.5.0
   glob: ^2.1.3
+  google_cloud: ^0.4.0
   google_cloud_firestore: ^0.5.0
   http: ^1.6.0
   meta: ^1.17.0


### PR DESCRIPTION
Closes #162. 

createFirebaseInternal() was hardcoding Credential.fromApplicationDefaultCredentials(), bypassing the smarter credential discovery in AppRegistry that reads client_email directly from the service account file. Removed the hardcoded credential so AppRegistry auto-discovers it from GOOGLE_APPLICATION_CREDENTIALS via _credentialFromEnv.