### PR TITLE
fix: request double read

### DIFF
--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -352,16 +352,24 @@ Future<(Request, FirebaseFunctionDeclaration?)> _tryMatchCloudEventFunction(
       // Structured content mode - try to parse JSON body
       bodyString = await request.readAsString();
 
-      final body = jsonDecode(bodyString) as Map<String, dynamic>;
+      final Map<String, dynamic> body;
+      try {
+        body = jsonDecode(bodyString) as Map<String, dynamic>;
+      } catch (e) {
+        // Invalid JSON - not a CloudEvent request
+        return (request.change(body: bodyString), null);
+      }
 
+      final bodyType = body['type'];
+      final bodySource = body['source'];
       // Check if this is a valid CloudEvent - if not, return reconstructed request
-      if (!body.containsKey('source') || !body.containsKey('type')) {
+      if (bodyType is! String || bodySource is! String) {
         // Return the reconstructed request since we consumed the body
         return (request.change(body: bodyString), null);
       }
 
-      source = body['source'] as String;
-      type = body['type'] as String;
+      source = bodySource;
+      type = bodyType;
     }
 
     // Now we have source and type from either headers or body

--- a/test/e2e/tests/https_oncall_tests.dart
+++ b/test/e2e/tests/https_oncall_tests.dart
@@ -51,6 +51,18 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
       );
     });
 
+    test('greet returns default name for missing "data"', () async {
+      final response = await client.post('greet', body: {});
+
+      expect(response.statusCode, equals(200));
+
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      expect(
+        json['result'],
+        equals(<String, dynamic>{'message': 'Hello, World!'}),
+      );
+    });
+
     test('greet returns correct content type', () async {
       final response = await client.call('greet', data: {'name': 'Test'});
 
@@ -164,6 +176,12 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
         json['result'],
         equals(<String, dynamic>{'message': 'Hello, World!'}),
       );
+    });
+
+    test('greetTyped fails when missing "data"', () async {
+      final response = await client.post('greetTyped', body: {});
+
+      expect(response.statusCode, isNot(equals(200)));
     });
 
     test('greetTyped returns correct content type', () async {

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -62,6 +62,16 @@ void runHttpsOnRequestTests(
       expect(response.statusCode, equals(200));
     });
 
+    test('hello-world accepts POST requests similar to a CloudEvent', () async {
+      print('POST ${client.baseUrl}/hello-world like CloudEvent');
+      final response = await client.post(
+        'hello-world',
+        body: {'type': 0, 'source': 1},
+      );
+
+      expect(response.statusCode, equals(200));
+    });
+
     test('calling non-existent function returns 404', () async {
       print('GET ${client.baseUrl}/non-existent-function');
       final response = await client.get('non-existent-function');


### PR DESCRIPTION
Currently, if `_tryMatchCloudEventFunction` receives invalid CloudEvent json data, the function fails without properly overriding the function body.

This PR fixes this by performing guarded assertions or explicit type checks.

This probably fixes #23 in its entirety.

Implementation notes:
An additional improvement to the current implementation could be lifting bodyString out of the try catch block and use it when catching any errors. However, as far as I can tell, no code should fail, and the try / catch is probably redundant.