### PR TITLE
fix: handle CORS preflight for onCall functions by default

### DIFF
--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -150,7 +150,7 @@ class HttpsNamespace extends FunctionsNamespace {
         (result) => result.data,
         (result) => result.toResponse(),
       );
-    }, allowedOrigins: options?.cors?.runtimeValue());
+    }, allowedOrigins: options?.cors?.runtimeValue() ?? ['*']);
   }
 
   /// Creates an HTTPS callable function with typed data.
@@ -237,7 +237,7 @@ class HttpsNamespace extends FunctionsNamespace {
           headers: {'Content-Type': 'application/json'},
         ),
       );
-    }, allowedOrigins: options?.cors?.runtimeValue());
+    }, allowedOrigins: options?.cors?.runtimeValue() ?? ['*']);
   }
 
   /// Internal handler for callable functions.

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -573,26 +573,32 @@ void main() {
         expect(func.allowedOrigins, ['https://example.com']);
       });
 
-      test('onCall defaults allowedOrigins to [*] when no cors option given', () {
-        https.onCall(
-          name: 'callableNoCors',
-          (request, response) async => CallableResult('OK'),
-        );
+      test(
+        'onCall defaults allowedOrigins to [*] when no cors option given',
+        () {
+          https.onCall(
+            name: 'callableNoCors',
+            (request, response) async => CallableResult('OK'),
+          );
 
-        final func = _findFunction(firebase, 'callable-no-cors')!;
-        expect(func.allowedOrigins, ['*']);
-      });
+          final func = _findFunction(firebase, 'callable-no-cors')!;
+          expect(func.allowedOrigins, ['*']);
+        },
+      );
 
-      test('onCallWithData defaults allowedOrigins to [*] when no cors option given', () {
-        https.onCallWithData<_GreetRequest, String>(
-          name: 'typedNoCors',
-          fromJson: _GreetRequest.fromJson,
-          (request, response) async => 'OK',
-        );
+      test(
+        'onCallWithData defaults allowedOrigins to [*] when no cors option given',
+        () {
+          https.onCallWithData<_GreetRequest, String>(
+            name: 'typedNoCors',
+            fromJson: _GreetRequest.fromJson,
+            (request, response) async => 'OK',
+          );
 
-        final func = _findFunction(firebase, 'typed-no-cors')!;
-        expect(func.allowedOrigins, ['*']);
-      });
+          final func = _findFunction(firebase, 'typed-no-cors')!;
+          expect(func.allowedOrigins, ['*']);
+        },
+      );
     });
   });
 }

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -572,6 +572,27 @@ void main() {
         )!;
         expect(func.allowedOrigins, ['https://example.com']);
       });
+
+      test('onCall defaults allowedOrigins to [*] when no cors option given', () {
+        https.onCall(
+          name: 'callableNoCors',
+          (request, response) async => CallableResult('OK'),
+        );
+
+        final func = _findFunction(firebase, 'callable-no-cors')!;
+        expect(func.allowedOrigins, ['*']);
+      });
+
+      test('onCallWithData defaults allowedOrigins to [*] when no cors option given', () {
+        https.onCallWithData<_GreetRequest, String>(
+          name: 'typedNoCors',
+          fromJson: _GreetRequest.fromJson,
+          (request, response) async => 'OK',
+        );
+
+        final func = _findFunction(firebase, 'typed-no-cors')!;
+        expect(func.allowedOrigins, ['*']);
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #183 .

`onCall` and `onCallWithData` registered functions with `allowedOrigins: null` when no `cors` option was set. The routing layer only responds to OPTIONS preflight requests when `allowedOrigins != null`, so browsers received 405/404 instead of CORS headers — breaking all Flutter Web clients calling Dart callable functions. 
  
Fix defaults `allowedOrigins` to `['*']` for callable functions, matching Node.js SDK behavior.