### PR TITLE
fix: normalize function names by lowercasing only, not camelCase-to-kebab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 0.7.0-wip
 
 - Fix manifest generation for function options declared with named factories,
   including `Memory.fromInt` in `CallableOptions`.
+- Fix normalize function names by lowercasing only, not camelCase-to-kebab
 
 ## 0.6.0
 

--- a/example/alerts/pubspec.yaml
+++ b/example/alerts/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/auth/pubspec.yaml
+++ b/example/auth/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/database/pubspec.yaml
+++ b/example/database/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/eventarc/pubspec.yaml
+++ b/example/eventarc/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/firestore/pubspec.yaml
+++ b/example/firestore/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/firestore_test/pubspec.yaml
+++ b/example/firestore_test/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/https/pubspec.yaml
+++ b/example/https/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/pubsub/pubspec.yaml
+++ b/example/pubsub/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/remoteconfig/pubspec.yaml
+++ b/example/remoteconfig/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/scheduler/pubspec.yaml
+++ b/example/scheduler/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/storage/pubspec.yaml
+++ b/example/storage/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/tasks/pubspec.yaml
+++ b/example/tasks/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/example/testlab/pubspec.yaml
+++ b/example/testlab/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/lib/src/common/cloud_run_id.dart
+++ b/lib/src/common/cloud_run_id.dart
@@ -20,44 +20,33 @@
 /// - Not end with a hyphen
 /// - Be less than 50 characters
 ///
-/// CamelCase is properly transformed to kebab-case:
-/// - `onDocumentCreated` → `on-document-created`
-/// - `helloWorld` → `hello-world`
+/// Names are lowercased as-is (no camelCase splitting), matching what the
+/// Cloud Functions v2 API does internally for Node.js and Python functions:
+/// - `helloWorld` → `helloworld`
+/// - `getAuthInfo` → `getauthinfo`
 ///
-/// Underscores and other separators become hyphens:
-/// - `onDocumentCreated_users_userId` → `on-document-created-users-user-id`
+/// Underscores and other invalid characters become hyphens:
+/// - `onDocumentCreated_users_userId` → `ondocumentcreated-users-userid`
 ///
 /// This function is used by both the build-time manifest generator and the
 /// runtime function registration to ensure consistent naming.
 String toCloudRunId(String name) {
-  // Step 1: Convert camelCase to kebab-case
-  // Insert hyphen before uppercase letters that follow a lowercase letter/digit
-  var id = name.replaceAllMapped(
-    RegExp(r'(?<=[a-z0-9])([A-Z])'),
-    (m) => '-${m.group(1)}',
-  );
-  // Handle consecutive uppercase followed by lowercase (e.g., HTTPSServer → HTTPS-Server)
-  id = id.replaceAllMapped(
-    RegExp(r'(?<=[A-Z])([A-Z][a-z])'),
-    (m) => '-${m.group(1)}',
-  );
+  // Step 1: Lowercase
+  var id = name.toLowerCase();
 
-  // Step 2: Lowercase
-  id = id.toLowerCase();
-
-  // Step 3: Replace non-alphanumeric chars with hyphens
+  // Step 2: Replace non-alphanumeric chars with hyphens
   id = id.replaceAll(RegExp(r'[^a-z0-9]'), '-');
 
-  // Step 4: Collapse consecutive hyphens
+  // Step 3: Collapse consecutive hyphens
   id = id.replaceAll(RegExp(r'-{2,}'), '-');
 
-  // Step 5: Remove leading hyphens/digits (must start with a letter)
+  // Step 4: Remove leading hyphens/digits (must start with a letter)
   id = id.replaceAll(RegExp(r'^[^a-z]+'), '');
 
-  // Step 6: Remove trailing hyphens
+  // Step 5: Remove trailing hyphens
   id = id.replaceAll(RegExp(r'-+$'), '');
 
-  // Step 7: Handle 50-char limit
+  // Step 6: Handle 50-char limit
   if (id.length >= 50) {
     // Use a deterministic hash suffix to avoid collisions
     final hash = _simpleHash(name);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ name: firebase_functions
 description: >-
   Cloud Functions for Dart with support for the Firebase Admin SDK,
   Cloud Storage and Firestore
-version: 0.6.0
+version: 0.7.0-wip
 repository: https://github.com/firebase/firebase-functions-dart
 
 environment:

--- a/test/e2e/helpers/emulator.dart
+++ b/test/e2e/helpers/emulator.dart
@@ -173,7 +173,7 @@ class EmulatorHelper {
         final request = await client
             .getUrl(
               Uri.parse(
-                'http://127.0.0.1:$functionsPort/demo-test/us-central1/hello-world',
+                'http://127.0.0.1:$functionsPort/demo-test/us-central1/helloworld',
               ),
             )
             .timeout(const Duration(seconds: 5));
@@ -183,7 +183,7 @@ class EmulatorHelper {
         await response.drain<void>();
         // Only consider ready if we get 200 (not 404 which means function not registered)
         if (response.statusCode == 200) {
-          print('Function hello-world responding on port $functionsPort');
+          print('Function helloworld responding on port $functionsPort');
           client.close();
           if (!_readyCompleter!.isCompleted) {
             _readyCompleter!.complete();

--- a/test/e2e/tests/https_oncall_tests.dart
+++ b/test/e2e/tests/https_oncall_tests.dart
@@ -105,7 +105,7 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
       'signInWithCode returns a custom token via Admin SDK createCustomToken',
       () async {
         final response = await client.call(
-          'sign-in-with-code',
+          'signinwithcode',
           data: <String, dynamic>{},
         );
 
@@ -120,7 +120,7 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
 
     test('getAuthInfo returns unauthenticated when no auth token', () async {
       final response = await client.call(
-        'get-auth-info',
+        'getauthinfo',
         data: <String, dynamic>{},
       );
 
@@ -169,7 +169,7 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
     });
 
     test('greetTyped returns expected response with name', () async {
-      final response = await client.call('greet-typed', data: {'name': 'Dart'});
+      final response = await client.call('greettyped', data: {'name': 'Dart'});
 
       expect(response.statusCode, equals(200));
 
@@ -182,7 +182,7 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
 
     test('greetTyped uses default name when not provided', () async {
       final response = await client.call(
-        'greet-typed',
+        'greettyped',
         data: <String, dynamic>{},
       );
 
@@ -202,14 +202,14 @@ void runHttpsOnCallTests(FunctionsHttpClient Function() getClient) {
     });
 
     test('greetTyped returns correct content type', () async {
-      final response = await client.call('greet-typed', data: {'name': 'Test'});
+      final response = await client.call('greettyped', data: {'name': 'Test'});
 
       expect(response.statusCode, equals(200));
       expect(response.headers['content-type'], contains('application/json'));
     });
 
     test('greetTyped rejects GET requests', () async {
-      final response = await client.get('greet-typed');
+      final response = await client.get('greettyped');
 
       expect(response.statusCode, isNot(equals(200)));
     });

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -32,40 +32,40 @@ void runHttpsOnRequestTests(
       client = getClient();
       emulator = getEmulator();
     });
-    test('hello-world returns expected response', () async {
-      print('GET ${client.baseUrl}/hello-world');
-      final response = await client.get('hello-world');
+    test('helloworld returns expected response', () async {
+      print('GET ${client.baseUrl}/helloworld');
+      final response = await client.get('helloworld');
 
       expect(response.statusCode, equals(200));
       expect(response.body, contains('Hello from Dart Functions!'));
     });
 
-    test('hello-world has correct content type', () async {
-      print('GET ${client.baseUrl}/hello-world');
-      final response = await client.get('hello-world');
+    test('helloworld has correct content type', () async {
+      print('GET ${client.baseUrl}/helloworld');
+      final response = await client.get('helloworld');
 
       expect(response.statusCode, equals(200));
       expect(response.headers['content-type'], contains('text/plain'));
     });
 
-    test('hello-world accepts GET requests', () async {
-      print('GET ${client.baseUrl}/hello-world');
-      final response = await client.get('hello-world');
+    test('helloworld accepts GET requests', () async {
+      print('GET ${client.baseUrl}/helloworld');
+      final response = await client.get('helloworld');
 
       expect(response.statusCode, equals(200));
     });
 
-    test('hello-world accepts POST requests', () async {
-      print('POST ${client.baseUrl}/hello-world');
-      final response = await client.post('hello-world');
+    test('helloworld accepts POST requests', () async {
+      print('POST ${client.baseUrl}/helloworld');
+      final response = await client.post('helloworld');
 
       expect(response.statusCode, equals(200));
     });
 
-    test('hello-world accepts POST requests similar to a CloudEvent', () async {
-      print('POST ${client.baseUrl}/hello-world like CloudEvent');
+    test('helloworld accepts POST requests similar to a CloudEvent', () async {
+      print('POST ${client.baseUrl}/helloworld like CloudEvent');
       final response = await client.post(
-        'hello-world',
+        'helloworld',
         body: {'type': 0, 'source': 1},
       );
 
@@ -89,7 +89,7 @@ void runHttpsOnRequestTests(
 
         for (var i = 0; i < 5; i++) {
           futures.add(() async {
-            final response = await client.get('hello-world');
+            final response = await client.get('helloworld');
             expect(response.statusCode, equals(200));
             expect(response.body, contains('Hello from Dart Functions!'));
           }());
@@ -101,21 +101,21 @@ void runHttpsOnRequestTests(
     );
 
     test('function is discoverable via emulator', () async {
-      print('GET ${client.baseUrl}/hello-world');
-      final response = await client.get('hello-world');
+      print('GET ${client.baseUrl}/helloworld');
+      final response = await client.get('helloworld');
 
       expect(
         response.statusCode,
         equals(200),
-        reason: 'Function hello-world should be deployed',
+        reason: 'Function helloworld should be deployed',
       );
     });
 
     test(
       'unexpected error returns INTERNAL without leaking sensitive details',
       () async {
-        print('GET ${client.baseUrl}/crash-with-secret');
-        final response = await client.get('crash-with-secret');
+        print('GET ${client.baseUrl}/crashwithsecret');
+        final response = await client.get('crashwithsecret');
 
         // Should return 500
         expect(response.statusCode, equals(500));
@@ -155,8 +155,8 @@ void runHttpsOnRequestTests(
     test(
       'unexpected runtime error returns INTERNAL without leaking internals',
       () async {
-        print('GET ${client.baseUrl}/crash-unexpected');
-        final response = await client.get('crash-unexpected');
+        print('GET ${client.baseUrl}/crashunexpected');
+        final response = await client.get('crashunexpected');
 
         // Should return 500
         expect(response.statusCode, equals(500));
@@ -187,8 +187,8 @@ void runHttpsOnRequestTests(
       emulator.clearOutputBuffer();
 
       // Make a request
-      print('GET ${client.baseUrl}/hello-world (verifying execution logs)');
-      final response = await client.get('hello-world');
+      print('GET ${client.baseUrl}/helloworld (verifying execution logs)');
+      final response = await client.get('helloworld');
 
       // Wait a bit for logs to be captured
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -198,7 +198,7 @@ void runHttpsOnRequestTests(
 
       // Verify Firebase emulator logged the execution
       final executionLogged = emulator.verifyFunctionExecution(
-        'us-central1-hello-world',
+        'us-central1-helloworld',
       );
       expect(
         executionLogged,

--- a/test/e2e/tests/integration_tests.dart
+++ b/test/e2e/tests/integration_tests.dart
@@ -37,8 +37,8 @@ void runIntegrationTests(String Function() getExamplePath) {
       final manifestContent = manifestFile.readAsStringSync();
       expect(
         manifestContent,
-        contains('hello-world'),
-        reason: 'Manifest should contain hello-world function',
+        contains('helloworld'),
+        reason: 'Manifest should contain helloworld function',
       );
     });
   });

--- a/test/e2e/tests/pubsub_tests.dart
+++ b/test/e2e/tests/pubsub_tests.dart
@@ -57,7 +57,7 @@ void runPubSubTests(
       final manifestContent = manifestFile.readAsStringSync();
       expect(
         manifestContent,
-        contains('on-message-published-mytopic'),
+        contains('onmessagepublished-mytopic'),
         reason: 'Manifest should contain Pub/Sub function',
       );
     });

--- a/test/e2e/tests/scheduler_tests.dart
+++ b/test/e2e/tests/scheduler_tests.dart
@@ -54,7 +54,7 @@ void runSchedulerTests(
       final manifestContent = manifestFile.readAsStringSync();
       expect(
         manifestContent,
-        contains('on-schedule-0-0'),
+        contains('onschedule-0-0'),
         reason: 'Manifest should contain basic scheduler function',
       );
       expect(
@@ -76,7 +76,7 @@ void runSchedulerTests(
 
       expect(
         manifestContent,
-        contains('on-schedule-0-9-15'),
+        contains('onschedule-0-9-15'),
         reason: 'Manifest should contain scheduler function with options',
       );
       expect(

--- a/test/e2e/tests/storage_tests.dart
+++ b/test/e2e/tests/storage_tests.dart
@@ -73,7 +73,7 @@ const _cloudEventContentType = 'application/cloudevents+json; charset=UTF-8';
 ///
 /// Needed because long names get truncated with a hash suffix by `toCloudRunId`.
 String? _findFunctionName(String manifestContent, String prefix) {
-  // Match a line like "  on-object-archived-demotestfirebasestorageapp:"
+  // Match a line like "  onobjectarchived-demotestfirebasestorageapp:"
   final pattern = RegExp('^\\s+($prefix[a-z0-9-]*):', multiLine: true);
   final match = pattern.firstMatch(manifestContent);
   return match?.group(1);
@@ -109,12 +109,12 @@ void runStorageTests(
       final manifestContent = manifestFile.readAsStringSync();
       expect(
         manifestContent,
-        contains('on-object-finalized-demotestfirebasestorageapp'),
+        contains('onobjectfinalized-demotestfirebasestorageapp'),
         reason: 'Manifest should contain Storage finalized function',
       );
       expect(
         manifestContent,
-        contains('on-object-deleted-demotestfirebasestorageapp'),
+        contains('onobjectdeleted-demotestfirebasestorageapp'),
         reason: 'Manifest should contain Storage deleted function',
       );
     });
@@ -293,7 +293,7 @@ void runStorageTests(
       final manifestContent = manifestFile.readAsStringSync();
       expect(
         manifestContent,
-        contains('on-object-archived-demotestfirebasestorageapp'),
+        contains('onobjectarchived-demotestfirebasestorageapp'),
         reason: 'Manifest should contain Storage archived function',
       );
     });

--- a/test/e2e/tests/storage_tests.dart
+++ b/test/e2e/tests/storage_tests.dart
@@ -436,8 +436,8 @@ void runStorageTests(
         '$examplePath/functions.yaml',
       ).readAsStringSync();
       functionName =
-          _findFunctionName(manifestContent, 'on-object-metadata-updated') ??
-          'on-object-metadata-updated-demotestfirebasestorageapp';
+          _findFunctionName(manifestContent, 'onobjectmetadataupdated') ??
+          'onobjectmetadataupdated-demotestfirebasestorageapp';
       print('Using function name: $functionName');
     });
 

--- a/test/fixtures/dart_reference/pubspec.yaml
+++ b/test/fixtures/dart_reference/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 
 dependencies:
   firebase_admin_sdk: ^0.5.0
-  firebase_functions: ^0.6.0-0
+  firebase_functions: ^0.7.0-wip
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -383,7 +383,7 @@ void main() {
       expect(dartFunc, isNotNull);
       expect(nodejsFunc, isNotNull);
 
-      expect(dartFunc!['entryPoint'], equals('greet-typed'));
+      expect(dartFunc!['entryPoint'], equals('greettyped'));
       expect(nodejsFunc!['entryPoint'], equals('greetTyped'));
       expect(dartFunc['callableTrigger'], isNotNull);
       expect(nodejsFunc['callableTrigger'], isNotNull);
@@ -409,7 +409,7 @@ void main() {
       expect(dartFunc, isNotNull);
       expect(nodejsFunc, isNotNull);
 
-      expect(dartFunc!['entryPoint'], equals('get-auth-info'));
+      expect(dartFunc!['entryPoint'], equals('getauthinfo'));
       expect(nodejsFunc!['entryPoint'], equals('getAuthInfo'));
       expect(dartFunc['callableTrigger'], isNotNull);
       expect(nodejsFunc['callableTrigger'], isNotNull);
@@ -442,7 +442,7 @@ void main() {
       expect(dartFunc, isNotNull);
       expect(nodejsFunc, isNotNull);
 
-      expect(dartFunc!['entryPoint'], equals('hello-world'));
+      expect(dartFunc!['entryPoint'], equals('helloworld'));
       expect(nodejsFunc!['entryPoint'], equals('helloWorld'));
       expect(dartFunc['platform'], equals('gcfv2'));
       expect(nodejsFunc['platform'], equals('gcfv2'));
@@ -496,7 +496,7 @@ void main() {
       expect(dartFunc, isNotNull);
       expect(nodejsFunc, isNotNull);
 
-      expect(dartFunc!['entryPoint'], equals('on-message-published-mytopic'));
+      expect(dartFunc!['entryPoint'], equals('onmessagepublished-mytopic'));
       expect(nodejsFunc!['entryPoint'], equals('onMessagePublished_mytopic'));
       expect(dartFunc['eventTrigger'], isNotNull);
       expect(nodejsFunc['eventTrigger'], isNotNull);
@@ -1223,7 +1223,7 @@ void main() {
       expect(dartFunc, isNotNull);
       expect(nodejsFunc, isNotNull);
 
-      expect(dartFunc!['entryPoint'], equals('on-config-updated'));
+      expect(dartFunc!['entryPoint'], equals('onconfigupdated'));
       expect(nodejsFunc!['entryPoint'], equals('onConfigUpdated'));
       expect(dartFunc['platform'], equals('gcfv2'));
       expect(nodejsFunc['platform'], equals('gcfv2'));
@@ -1282,7 +1282,7 @@ void main() {
 
       expect(
         dartFunc!['entryPoint'],
-        equals('on-object-finalized-demotestfirebasestorageapp'),
+        equals('onobjectfinalized-demotestfirebasestorageapp'),
       );
       expect(
         nodejsFunc!['entryPoint'],
@@ -1461,7 +1461,7 @@ void main() {
 
       expect(
         dartFunc!['entryPoint'],
-        equals('on-custom-event-published-comexamplemyevent'),
+        equals('oncustomeventpublished-comexamplemyevent'),
       );
       expect(
         nodejsFunc!['entryPoint'],
@@ -1715,7 +1715,7 @@ void main() {
       expect(dartFunc, isNotNull);
       expect(nodejsFunc, isNotNull);
 
-      expect(dartFunc!['entryPoint'], equals('on-test-matrix-completed'));
+      expect(dartFunc!['entryPoint'], equals('ontestmatrixcompleted'));
       expect(nodejsFunc!['entryPoint'], equals('onTestMatrixCompleted'));
       expect(dartFunc['platform'], equals('gcfv2'));
       expect(nodejsFunc['platform'], equals('gcfv2'));

--- a/test/unit/error_logging_test.dart
+++ b/test/unit/error_logging_test.dart
@@ -113,7 +113,7 @@ void main() {
         );
         final request = Request(
           'GET',
-          Uri.parse('http://localhost/crash-endpoint'),
+          Uri.parse('http://localhost/crashendpoint'),
         );
         final response = await func.handler(request);
 
@@ -136,10 +136,8 @@ void main() {
         throw NotFoundError('User 42 not found');
       });
 
-      final func = firebase.functions.firstWhere(
-        (f) => f.name == 'knownerror',
-      );
-      final request = Request('GET', Uri.parse('http://localhost/known-error'));
+      final func = firebase.functions.firstWhere((f) => f.name == 'knownerror');
+      final request = Request('GET', Uri.parse('http://localhost/knownerror'));
       final response = await func.handler(request);
 
       expect(response.statusCode, 404);

--- a/test/unit/error_logging_test.dart
+++ b/test/unit/error_logging_test.dart
@@ -109,7 +109,7 @@ void main() {
         });
 
         final func = firebase.functions.firstWhere(
-          (f) => f.name == 'crash-endpoint',
+          (f) => f.name == 'crashendpoint',
         );
         final request = Request(
           'GET',
@@ -137,7 +137,7 @@ void main() {
       });
 
       final func = firebase.functions.firstWhere(
-        (f) => f.name == 'known-error',
+        (f) => f.name == 'knownerror',
       );
       final request = Request('GET', Uri.parse('http://localhost/known-error'));
       final response = await func.handler(request);
@@ -166,7 +166,7 @@ void main() {
       });
 
       final func = firebase.functions.firstWhere(
-        (f) => f.name == 'on-message-published-testtopic',
+        (f) => f.name == 'onmessagepublished-testtopic',
       );
 
       // Send a valid Pub/Sub CloudEvent
@@ -190,7 +190,7 @@ void main() {
 
       final request = Request(
         'POST',
-        Uri.parse('http://localhost/on-message-published-testtopic'),
+        Uri.parse('http://localhost/onmessagepublished-testtopic'),
         body: jsonEncode(cloudEvent),
         headers: {'content-type': 'application/json'},
       );
@@ -211,12 +211,12 @@ void main() {
       });
 
       final func = firebase.functions.firstWhere(
-        (f) => f.name == 'on-schedule-0-0',
+        (f) => f.name == 'onschedule-0-0',
       );
 
       final request = Request(
         'POST',
-        Uri.parse('http://localhost/on-schedule-0-0'),
+        Uri.parse('http://localhost/onschedule-0-0'),
         headers: {'x-cloudscheduler-scheduletime': '2024-01-01T00:00:00Z'},
       );
       final response = await func.handler(request);

--- a/test/unit/global_options_test.dart
+++ b/test/unit/global_options_test.dart
@@ -74,8 +74,7 @@ final globalOptions = new GlobalOptions(
       });
       final manifest = loadYaml(yaml) as YamlMap;
       final endpoint =
-          (manifest['endpoints'] as YamlMap)['globalresetendpoint']
-              as YamlMap;
+          (manifest['endpoints'] as YamlMap)['globalresetendpoint'] as YamlMap;
 
       expect(endpoint['timeoutSeconds'], isNull);
     });

--- a/test/unit/global_options_test.dart
+++ b/test/unit/global_options_test.dart
@@ -49,7 +49,7 @@ final endpointOptions = new HttpsOptions(
       });
       final manifest = loadYaml(yaml) as YamlMap;
       final endpoint =
-          (manifest['endpoints'] as YamlMap)['global-endpoint'] as YamlMap;
+          (manifest['endpoints'] as YamlMap)['globalendpoint'] as YamlMap;
 
       expect(endpoint['region'], equals(['us-west1']));
       expect(endpoint['availableMemoryMb'], equals(1024));
@@ -74,7 +74,7 @@ final globalOptions = new GlobalOptions(
       });
       final manifest = loadYaml(yaml) as YamlMap;
       final endpoint =
-          (manifest['endpoints'] as YamlMap)['global-reset-endpoint']
+          (manifest['endpoints'] as YamlMap)['globalresetendpoint']
               as YamlMap;
 
       expect(endpoint['timeoutSeconds'], isNull);

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -56,7 +56,7 @@ void main() {
           (request) async => Response.ok('Hello'),
         );
 
-        expect(_findFunction(firebase, 'test-function'), isNotNull);
+        expect(_findFunction(firebase, 'testfunction'), isNotNull);
       });
 
       test('handler receives request and returns response', () async {
@@ -65,10 +65,10 @@ void main() {
           (request) async => Response.ok('Hello, World!'),
         );
 
-        final func = _findFunction(firebase, 'test-function')!;
+        final func = _findFunction(firebase, 'testfunction')!;
         final request = Request(
           'GET',
-          Uri.parse('http://localhost/test-function'),
+          Uri.parse('http://localhost/testfunction'),
         );
         final response = await func.handler(request);
 
@@ -81,10 +81,10 @@ void main() {
           throw NotFoundError('Resource not found');
         });
 
-        final func = _findFunction(firebase, 'error-function')!;
+        final func = _findFunction(firebase, 'errorfunction')!;
         final request = Request(
           'GET',
-          Uri.parse('http://localhost/error-function'),
+          Uri.parse('http://localhost/errorfunction'),
         );
         final response = await func.handler(request);
 
@@ -101,10 +101,10 @@ void main() {
           throw Exception('Unexpected crash');
         });
 
-        final func = _findFunction(firebase, 'crash-function')!;
+        final func = _findFunction(firebase, 'crashfunction')!;
         final request = Request(
           'GET',
-          Uri.parse('http://localhost/crash-function'),
+          Uri.parse('http://localhost/crashfunction'),
         );
         final response = await func.handler(request);
 
@@ -121,7 +121,7 @@ void main() {
           (request) async => Response.ok('OK'),
         );
 
-        final func = _findFunction(firebase, 'external-function')!;
+        final func = _findFunction(firebase, 'externalfunction')!;
         expect(func.external, isTrue);
       });
 
@@ -130,7 +130,7 @@ void main() {
           throw UnauthenticatedError('Not logged in');
         });
 
-        final func = _findFunction(firebase, 'unauthorized-function')!;
+        final func = _findFunction(firebase, 'unauthorizedfunction')!;
         final request = Request('GET', Uri.parse('http://localhost/test'));
         final response = await func.handler(request);
 
@@ -146,7 +146,7 @@ void main() {
         final body = jsonEncode({'data': data});
         return Request(
           'POST',
-          Uri.parse('http://localhost/test-function'),
+          Uri.parse('http://localhost/testfunction'),
           headers: {'content-type': 'application/json', ...headers},
           body: body,
         );
@@ -158,7 +158,7 @@ void main() {
           (request, response) async => CallableResult('OK'),
         );
 
-        expect(_findFunction(firebase, 'callable-function'), isNotNull);
+        expect(_findFunction(firebase, 'callablefunction'), isNotNull);
       });
 
       test('handler returns wrapped result', () async {
@@ -168,7 +168,7 @@ void main() {
           return CallableResult({'message': 'Hello, $name!'});
         });
 
-        final func = _findFunction(firebase, 'greet-function')!;
+        final func = _findFunction(firebase, 'greetfunction')!;
         final request = createCallableRequest(data: {'name': 'World'});
         final response = await func.handler(request);
 
@@ -185,10 +185,10 @@ void main() {
           (request, response) async => CallableResult('OK'),
         );
 
-        final func = _findFunction(firebase, 'post-only-function')!;
+        final func = _findFunction(firebase, 'postonlyfunction')!;
         final request = Request(
           'GET',
-          Uri.parse('http://localhost/post-only-function'),
+          Uri.parse('http://localhost/postonlyfunction'),
           headers: {'content-type': 'application/json'},
         );
         final response = await func.handler(request);
@@ -204,10 +204,10 @@ void main() {
           (request, response) async => CallableResult('OK'),
         );
 
-        final func = _findFunction(firebase, 'json-only-function')!;
+        final func = _findFunction(firebase, 'jsononlyfunction')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/json-only-function'),
+          Uri.parse('http://localhost/jsononlyfunction'),
           headers: {'content-type': 'text/plain'},
           body: '{"data": "test"}',
         );
@@ -221,7 +221,7 @@ void main() {
           throw PermissionDeniedError('Not authorized');
         });
 
-        final func = _findFunction(firebase, 'error-function')!;
+        final func = _findFunction(firebase, 'errorfunction')!;
         final request = createCallableRequest();
         final response = await func.handler(request);
 
@@ -236,7 +236,7 @@ void main() {
           throw StateError('Something broke');
         });
 
-        final func = _findFunction(firebase, 'crash-function')!;
+        final func = _findFunction(firebase, 'crashfunction')!;
         final request = createCallableRequest();
         final response = await func.handler(request);
 
@@ -250,7 +250,7 @@ void main() {
           return CallableResult('result');
         });
 
-        final func = _findFunction(firebase, 'non-stream-function')!;
+        final func = _findFunction(firebase, 'nonstreamfunction')!;
         final request = createCallableRequest();
         final response = await func.handler(request);
 
@@ -266,7 +266,7 @@ void main() {
           return JsonResult({'status': 'ok', 'count': 42});
         });
 
-        final func = _findFunction(firebase, 'json-result-function')!;
+        final func = _findFunction(firebase, 'jsonresultfunction')!;
         final request = createCallableRequest();
         final response = await func.handler(request);
 
@@ -280,7 +280,7 @@ void main() {
             throw InvalidArgumentError('Invalid data');
           });
 
-          final func = _findFunction(firebase, 'stream-error-function')!;
+          final func = _findFunction(firebase, 'streamerrorfunction')!;
           final request = createCallableRequest(
             headers: {'accept': 'text/event-stream'},
           );
@@ -306,7 +306,7 @@ void main() {
               throw Exception('Unexpected crash');
             });
 
-            final func = _findFunction(firebase, 'stream-crash-function')!;
+            final func = _findFunction(firebase, 'streamcrashfunction')!;
             final request = createCallableRequest(
               headers: {'accept': 'text/event-stream'},
             );
@@ -334,7 +334,7 @@ void main() {
             return CallableResult('success');
           });
 
-          final func = _findFunction(firebase, 'stream-success-function')!;
+          final func = _findFunction(firebase, 'streamsuccessfunction')!;
           final request = createCallableRequest(
             headers: {'accept': 'text/event-stream'},
           );
@@ -364,7 +364,7 @@ void main() {
             return CallableResult('done');
           });
 
-          final func = _findFunction(firebase, 'stream-stream-error-function')!;
+          final func = _findFunction(firebase, 'streamstreamerrorfunction')!;
           final request = createCallableRequest(
             headers: {'accept': 'text/event-stream'},
           );
@@ -407,7 +407,7 @@ void main() {
               return CallableResult('done');
             });
 
-            final func = _findFunction(firebase, 'bg-stream-function')!;
+            final func = _findFunction(firebase, 'bgstreamfunction')!;
             final request = createCallableRequest(
               headers: {'accept': 'text/event-stream'},
             );
@@ -440,7 +440,7 @@ void main() {
         final body = jsonEncode({'data': data});
         return Request(
           'POST',
-          Uri.parse('http://localhost/test-function'),
+          Uri.parse('http://localhost/testfunction'),
           headers: {'content-type': 'application/json', ...headers},
           body: body,
         );
@@ -455,7 +455,7 @@ void main() {
           },
         );
 
-        expect(_findFunction(firebase, 'typed-function'), isNotNull);
+        expect(_findFunction(firebase, 'typedfunction'), isNotNull);
       });
 
       test('deserializes input using fromJson', () async {
@@ -469,7 +469,7 @@ void main() {
           },
         );
 
-        final func = _findFunction(firebase, 'typed-function')!;
+        final func = _findFunction(firebase, 'typedfunction')!;
         final request = createCallableRequest(data: {'name': 'World'});
         final response = await func.handler(request);
 
@@ -487,7 +487,7 @@ void main() {
           },
         );
 
-        final func = _findFunction(firebase, 'typed-output-function')!;
+        final func = _findFunction(firebase, 'typedoutputfunction')!;
         final request = createCallableRequest(data: {'name': 'World'});
         final response = await func.handler(request);
 
@@ -504,10 +504,10 @@ void main() {
           (request, response) async => 'OK',
         );
 
-        final func = _findFunction(firebase, 'post-only-typed-function')!;
+        final func = _findFunction(firebase, 'postonlytypedfunction')!;
         final request = Request(
           'GET',
-          Uri.parse('http://localhost/post-only-typed-function'),
+          Uri.parse('http://localhost/postonlytypedfunction'),
           headers: {'content-type': 'application/json'},
         );
         final response = await func.handler(request);
@@ -524,7 +524,7 @@ void main() {
           },
         );
 
-        final func = _findFunction(firebase, 'error-typed-function')!;
+        final func = _findFunction(firebase, 'errortypedfunction')!;
         final request = createCallableRequest(data: {'name': ''});
         final response = await func.handler(request);
 
@@ -543,7 +543,7 @@ void main() {
           (request) async => Response.ok('OK'),
         );
 
-        final func = _findFunction(firebase, 'options-function')!;
+        final func = _findFunction(firebase, 'optionsfunction')!;
         expect(func.allowedOrigins, ['https://example.com']);
       });
 
@@ -556,7 +556,7 @@ void main() {
           (request, response) async => CallableResult('OK'),
         );
 
-        expect(_findFunction(firebase, 'callable-options-function'), isNotNull);
+        expect(_findFunction(firebase, 'callableoptionsfunction'), isNotNull);
       });
 
       test('CallableOptions can be provided passing allowedOrigins', () {
@@ -568,7 +568,7 @@ void main() {
 
         final func = _findFunction(
           firebase,
-          'callable-options-function-with-origins',
+          'callableoptionsfunctionwithorigins',
         )!;
         expect(func.allowedOrigins, ['https://example.com']);
       });
@@ -581,7 +581,7 @@ void main() {
             (request, response) async => CallableResult('OK'),
           );
 
-          final func = _findFunction(firebase, 'callable-no-cors')!;
+          final func = _findFunction(firebase, 'callablenocors')!;
           expect(func.allowedOrigins, ['*']);
         },
       );
@@ -595,7 +595,7 @@ void main() {
             (request, response) async => 'OK',
           );
 
-          final func = _findFunction(firebase, 'typed-no-cors')!;
+          final func = _findFunction(firebase, 'typednocors')!;
           expect(func.allowedOrigins, ['*']);
         },
       );

--- a/test/unit/remote_config_test.dart
+++ b/test/unit/remote_config_test.dart
@@ -64,7 +64,7 @@ Request _createRemoteConfigRequest({
 
   return Request(
     'POST',
-    Uri.parse('http://localhost/on-config-updated'),
+    Uri.parse('http://localhost/onconfigupdated'),
     body: jsonEncode(cloudEvent),
     headers: {'content-type': 'application/json'},
   );
@@ -88,13 +88,13 @@ void main() {
       test('registers function with firebase', () {
         remoteConfig.onConfigUpdated((event) async {});
 
-        expect(_findFunction(firebase, 'on-config-updated'), isNotNull);
+        expect(_findFunction(firebase, 'onconfigupdated'), isNotNull);
       });
 
       test('registered function is not external', () {
         remoteConfig.onConfigUpdated((event) async {});
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         expect(func.external, isFalse);
       });
 
@@ -105,7 +105,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final request = _createRemoteConfigRequest(
           versionNumber: 42,
           description: 'My config update',
@@ -132,7 +132,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(_createRemoteConfigRequest());
 
         expect(response.statusCode, 200);
@@ -156,7 +156,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(
           _createRemoteConfigRequest(updateOrigin: 'REST_API'),
         );
@@ -172,7 +172,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(
           _createRemoteConfigRequest(updateType: 'FORCED_UPDATE'),
         );
@@ -188,7 +188,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(
           _createRemoteConfigRequest(updateType: 'ROLLBACK', rollbackSource: 5),
         );
@@ -205,7 +205,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(_createRemoteConfigRequest());
 
         expect(response.statusCode, 200);
@@ -215,7 +215,7 @@ void main() {
       test('returns 200 on success', () async {
         remoteConfig.onConfigUpdated((event) async {});
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(_createRemoteConfigRequest());
 
         expect(response.statusCode, 200);
@@ -226,7 +226,7 @@ void main() {
           throw Exception('Handler error');
         });
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final response = await func.handler(_createRemoteConfigRequest());
 
         expect(response.statusCode, 500);
@@ -237,10 +237,10 @@ void main() {
       test('returns 400 for invalid CloudEvent', () async {
         remoteConfig.onConfigUpdated((event) async {});
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-config-updated'),
+          Uri.parse('http://localhost/onconfigupdated'),
           body: 'not json',
           headers: {'content-type': 'application/json'},
         );
@@ -252,10 +252,10 @@ void main() {
       test('returns 400 for wrong event type', () async {
         remoteConfig.onConfigUpdated((event) async {});
 
-        final func = _findFunction(firebase, 'on-config-updated')!;
+        final func = _findFunction(firebase, 'onconfigupdated')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-config-updated'),
+          Uri.parse('http://localhost/onconfigupdated'),
           body: jsonEncode({
             'specversion': '1.0',
             'id': 'test',

--- a/test/unit/scheduler_namespace_test.dart
+++ b/test/unit/scheduler_namespace_test.dart
@@ -48,15 +48,15 @@ void main() {
       test('registers function with firebase', () {
         scheduler.onSchedule(schedule: '0 0 * * *', (event) async {});
 
-        // Function name: schedule '0 0 * * *' becomes 'on-schedule-0-0' (kebab-case Cloud Run ID)
-        expect(_findFunction(firebase, 'on-schedule-0-0'), isNotNull);
+        // Function name: schedule '0 0 * * *' becomes 'onschedule-0-0'
+        expect(_findFunction(firebase, 'onschedule-0-0'), isNotNull);
       });
 
       test('generates correct function name from schedule', () {
         scheduler.onSchedule(schedule: '*/5 * * * *', (event) async {});
 
-        // '*/5 * * * *' -> 'on-schedule-5' (removes *, /, converts to kebab-case)
-        expect(_findFunction(firebase, 'on-schedule-5'), isNotNull);
+        // '*/5 * * * *' -> 'onschedule-5' (removes *, /)
+        expect(_findFunction(firebase, 'onschedule-5'), isNotNull);
       });
 
       test('handler receives scheduled event', () async {
@@ -66,10 +66,10 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-schedule-0-0')!;
+        final func = _findFunction(firebase, 'onschedule-0-0')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-schedule-0-0'),
+          Uri.parse('http://localhost/onschedule-0-0'),
           headers: {
             'x-cloudscheduler-jobname':
                 'projects/test/locations/us-central1/jobs/myjob',
@@ -94,10 +94,10 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-schedule-0-0')!;
+        final func = _findFunction(firebase, 'onschedule-0-0')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-schedule-0-0'),
+          Uri.parse('http://localhost/onschedule-0-0'),
           headers: {'x-cloudscheduler-scheduletime': '2024-01-01T00:00:00Z'},
         );
         final response = await func.handler(request);
@@ -115,10 +115,10 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-schedule-0-0')!;
+        final func = _findFunction(firebase, 'onschedule-0-0')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-schedule-0-0'),
+          Uri.parse('http://localhost/onschedule-0-0'),
           headers: {},
         );
         final response = await func.handler(request);
@@ -138,10 +138,10 @@ void main() {
           // Success - do nothing
         });
 
-        final func = _findFunction(firebase, 'on-schedule-0-0')!;
+        final func = _findFunction(firebase, 'onschedule-0-0')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-schedule-0-0'),
+          Uri.parse('http://localhost/onschedule-0-0'),
           headers: {'x-cloudscheduler-scheduletime': '2024-01-01T00:00:00Z'},
         );
         final response = await func.handler(request);
@@ -154,10 +154,10 @@ void main() {
           throw Exception('Handler error');
         });
 
-        final func = _findFunction(firebase, 'on-schedule-0-0')!;
+        final func = _findFunction(firebase, 'onschedule-0-0')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-schedule-0-0'),
+          Uri.parse('http://localhost/onschedule-0-0'),
           headers: {'x-cloudscheduler-scheduletime': '2024-01-01T00:00:00Z'},
         );
         final response = await func.handler(request);
@@ -180,7 +180,7 @@ void main() {
           (event) async {},
         );
 
-        expect(_findFunction(firebase, 'on-schedule-0-0'), isNotNull);
+        expect(_findFunction(firebase, 'onschedule-0-0'), isNotNull);
       });
 
       test('handles case-insensitive headers', () async {
@@ -190,10 +190,10 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-schedule-0-0')!;
+        final func = _findFunction(firebase, 'onschedule-0-0')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-schedule-0-0'),
+          Uri.parse('http://localhost/onschedule-0-0'),
           headers: {
             'X-CloudScheduler-JobName': 'test-job',
             'X-CloudScheduler-ScheduleTime': '2024-01-01T00:00:00Z',

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -66,7 +66,7 @@ Request _createStorageRequest({
 
   return Request(
     'POST',
-    Uri.parse('http://localhost/on-object-finalized-mybucket'),
+    Uri.parse('http://localhost/onobjectfinalized-mybucket'),
     body: jsonEncode(cloudEvent),
     headers: {'content-type': 'application/json'},
   );
@@ -91,7 +91,7 @@ void main() {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
         expect(
-          _findFunction(firebase, 'on-object-finalized-mybucket'),
+          _findFunction(firebase, 'onobjectfinalized-mybucket'),
           isNotNull,
         );
       });
@@ -99,7 +99,7 @@ void main() {
       test('registered function is not external', () {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         expect(func.external, isFalse);
       });
 
@@ -110,7 +110,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         final request = _createStorageRequest(
           objectName: 'uploads/image.png',
           contentType: 'image/png',
@@ -134,7 +134,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         final response = await func.handler(_createStorageRequest());
 
         expect(response.statusCode, 200);
@@ -156,7 +156,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         await func.handler(_createStorageRequest());
 
         expect(receivedEvent!.bucket, 'my-bucket');
@@ -168,7 +168,7 @@ void main() {
         storage.onObjectArchived(bucket: 'my-bucket', (event) async {});
 
         expect(
-          _findFunction(firebase, 'on-object-archived-mybucket'),
+          _findFunction(firebase, 'onobjectarchived-mybucket'),
           isNotNull,
         );
       });
@@ -180,7 +180,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-object-archived-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectarchived-mybucket')!;
         final request = _createStorageRequest(
           eventType: 'google.cloud.storage.object.v1.archived',
         );
@@ -197,7 +197,7 @@ void main() {
         storage.onObjectDeleted(bucket: 'my-bucket', (event) async {});
 
         expect(
-          _findFunction(firebase, 'on-object-deleted-mybucket'),
+          _findFunction(firebase, 'onobjectdeleted-mybucket'),
           isNotNull,
         );
       });
@@ -209,7 +209,7 @@ void main() {
           receivedEvent = event;
         });
 
-        final func = _findFunction(firebase, 'on-object-deleted-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectdeleted-mybucket')!;
         final request = _createStorageRequest(
           eventType: 'google.cloud.storage.object.v1.deleted',
         );
@@ -226,7 +226,7 @@ void main() {
         storage.onObjectMetadataUpdated(bucket: 'my-bucket', (event) async {});
 
         expect(
-          _findFunction(firebase, 'on-object-metadata-updated-mybucket'),
+          _findFunction(firebase, 'onobjectmetadataupdated-mybucket'),
           isNotNull,
         );
       });
@@ -240,7 +240,7 @@ void main() {
 
         final func = _findFunction(
           firebase,
-          'on-object-metadata-updated-mybucket',
+          'onobjectmetadataupdated-mybucket',
         )!;
         final request = _createStorageRequest(
           eventType: 'google.cloud.storage.object.v1.metadataUpdated',
@@ -262,7 +262,7 @@ void main() {
         storage.onObjectFinalized(bucket: 'my-test-bucket', (event) async {});
 
         expect(
-          _findFunction(firebase, 'on-object-finalized-mytestbucket'),
+          _findFunction(firebase, 'onobjectfinalized-mytestbucket'),
           isNotNull,
         );
       });
@@ -276,7 +276,7 @@ void main() {
         expect(
           _findFunction(
             firebase,
-            'on-object-finalized-demotestfirebasestorageapp',
+            'onobjectfinalized-demotestfirebasestorageapp',
           ),
           isNotNull,
         );
@@ -287,7 +287,7 @@ void main() {
       test('returns 200 on success', () async {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         final response = await func.handler(_createStorageRequest());
 
         expect(response.statusCode, 200);
@@ -298,7 +298,7 @@ void main() {
           throw Exception('Handler error');
         });
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         final response = await func.handler(_createStorageRequest());
 
         expect(response.statusCode, 500);
@@ -309,10 +309,10 @@ void main() {
       test('returns 400 for invalid CloudEvent', () async {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-object-finalized-mybucket'),
+          Uri.parse('http://localhost/onobjectfinalized-mybucket'),
           body: 'not json',
           headers: {'content-type': 'application/json'},
         );
@@ -324,10 +324,10 @@ void main() {
       test('returns 400 for wrong event type', () async {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
-        final func = _findFunction(firebase, 'on-object-finalized-mybucket')!;
+        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
         final request = Request(
           'POST',
-          Uri.parse('http://localhost/on-object-finalized-mybucket'),
+          Uri.parse('http://localhost/onobjectfinalized-mybucket'),
           body: jsonEncode({
             'specversion': '1.0',
             'id': 'test',

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -167,10 +167,7 @@ void main() {
       test('registers function with firebase', () {
         storage.onObjectArchived(bucket: 'my-bucket', (event) async {});
 
-        expect(
-          _findFunction(firebase, 'onobjectarchived-mybucket'),
-          isNotNull,
-        );
+        expect(_findFunction(firebase, 'onobjectarchived-mybucket'), isNotNull);
       });
 
       test('handler receives StorageEvent', () async {
@@ -196,10 +193,7 @@ void main() {
       test('registers function with firebase', () {
         storage.onObjectDeleted(bucket: 'my-bucket', (event) async {});
 
-        expect(
-          _findFunction(firebase, 'onobjectdeleted-mybucket'),
-          isNotNull,
-        );
+        expect(_findFunction(firebase, 'onobjectdeleted-mybucket'), isNotNull);
       });
 
       test('handler receives StorageEvent', () async {


### PR DESCRIPTION
Closes #181 

Dart functions deploy directly to the Cloud Run API, which requires the service ID to be lowercased. The previous implementation also converted camelCase to kebab-case (helloWorld → hello-world), which differs from what the Cloud Functions v2 API does internally for Node.js and Python functions (just lowercases: helloWorld → helloworld).

This change removes the camelCase splitting so Dart naming is consistent with other runtimes.

⚠️  Breaking change: existing deployed functions will have new Cloud Run service IDs on next deploy.