### PR TITLE
feat: add proper support for `@` shorthand in service account options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Document and test `ServiceAccount('service-account@')` project-relative
+  shorthand parity with the Node.js SDK.
+
 ## 0.6.0
 
 - Add `runFunctions` as the primary API.

--- a/doc/config.md
+++ b/doc/config.md
@@ -86,6 +86,42 @@ firebase.https.onRequest(
 );
 ```
 
+## Function Service Account
+
+Use the `serviceAccount` option to choose which service account a function runs
+as. This matches the Firebase Functions Node.js SDK format: pass either the full
+service account email or the project-relative shorthand ending in `@`.
+
+```dart
+firebase.https.onRequest(
+  name: 'hello',
+  options: const HttpsOptions(
+    // Expands during deployment to:
+    // my-account@<project-id>.iam.gserviceaccount.com
+    serviceAccount: ServiceAccount('my-account@'),
+  ),
+  (request) async => Response.ok('Hello from Dart!'),
+);
+```
+
+You can also provide the full email when the service account is not
+project-relative:
+
+```dart
+firebase.https.onRequest(
+  name: 'helloWithFullServiceAccount',
+  options: const HttpsOptions(
+    serviceAccount: ServiceAccount(
+      'my-account@my-project.iam.gserviceaccount.com',
+    ),
+  ),
+  (request) async => Response.ok('Hello from Dart!'),
+);
+```
+
+Do not strip the trailing `@` from the shorthand form. `my-account@` is the
+cross-SDK shorthand; `my-account` is not equivalent.
+
 ## Firebase Admin SDK
 
 The Functions runtime uses a Firebase Admin SDK app for features such as

--- a/lib/src/common/options.dart
+++ b/lib/src/common/options.dart
@@ -204,6 +204,12 @@ typedef Instances = DeployOption<int>;
 typedef Omit = Option<bool>;
 typedef PreserveExternalChanges = Option<bool>;
 typedef Region = DeployOption<SupportedRegion>;
+
+/// Service account to run the function as.
+///
+/// Accepts a full service account email, such as
+/// `my-account@my-project.iam.gserviceaccount.com`, or the Firebase Functions
+/// project-relative shorthand `my-account@`.
 typedef ServiceAccount = DeployOption<String>;
 typedef TimeoutSeconds = DeployOption<int>;
 typedef VpcConnector = DeployOption<String>;

--- a/test/e2e/tests/integration_tests.dart
+++ b/test/e2e/tests/integration_tests.dart
@@ -41,5 +41,33 @@ void runIntegrationTests(String Function() getExamplePath) {
         reason: 'Manifest should contain hello-world function',
       );
     });
+
+    test('service account shorthand is preserved in manifest', () {
+      final manifestPath = '$examplePath/functions.yaml';
+      final manifestFile = File(manifestPath);
+
+      expect(
+        manifestFile.existsSync(),
+        isTrue,
+        reason: 'functions.yaml should exist',
+      );
+
+      final manifestContent = manifestFile.readAsStringSync();
+      expect(
+        manifestContent,
+        contains('service-account-shorthand'),
+        reason: 'Manifest should contain serviceAccountShorthand function',
+      );
+      expect(
+        manifestContent,
+        contains('serviceAccountEmail: super-account@'),
+        reason: 'Manifest should preserve project-relative service account',
+      );
+      expect(
+        manifestContent,
+        isNot(contains('serviceAccountEmail: super-account\n')),
+        reason: 'Manifest should not strip the trailing @ shorthand marker',
+      );
+    });
   });
 }

--- a/test/e2e/tests/integration_tests.dart
+++ b/test/e2e/tests/integration_tests.dart
@@ -55,7 +55,7 @@ void runIntegrationTests(String Function() getExamplePath) {
       final manifestContent = manifestFile.readAsStringSync();
       expect(
         manifestContent,
-        contains('service-account-shorthand'),
+        contains('serviceaccountshorthand'),
         reason: 'Manifest should contain serviceAccountShorthand function',
       );
       expect(

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -675,6 +675,15 @@ void main(List<String> args) async {
       (request) async => Response.ok('HTTPS with all options'),
     );
 
+    // HTTPS onRequest with project-relative service account shorthand.
+    firebase.https.onRequest(
+      name: 'serviceAccountShorthand',
+      options: const HttpsOptions(
+        serviceAccount: ServiceAccount('super-account@'),
+      ),
+      (request) async => Response.ok('HTTPS with service account shorthand'),
+    );
+
     // Callable with ALL CallableOptions
     firebase.https.onCall(
       name: 'callableFull',

--- a/test/fixtures/nodejs_reference/index.js
+++ b/test/fixtures/nodejs_reference/index.js
@@ -578,6 +578,16 @@ exports.httpsFull = onRequest(
   }
 );
 
+// HTTPS onRequest with project-relative service account shorthand.
+exports.serviceAccountShorthand = onRequest(
+  {
+    serviceAccount: "super-account@"
+  },
+  (request, response) => {
+    response.send("HTTPS with service account shorthand");
+  }
+);
+
 // Callable with ALL CallableOptions
 exports.callableFull = onCall(
   {

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -327,14 +327,14 @@ void main() {
 
       expect(
         dartEndpoints.keys.length,
-        equals(52),
+        equals(53),
         reason:
-            'Should discover 52 functions (6 Callable + 4 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
+            'Should discover 53 functions (6 Callable + 5 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
       );
       expect(
         nodejsEndpoints.keys.length,
-        equals(52),
-        reason: 'Node.js reference should also have 52 endpoints',
+        equals(53),
+        reason: 'Node.js reference should also have 53 endpoints',
       );
 
       // Verify both manifests have the same endpoints (normalized via
@@ -1829,6 +1829,17 @@ void main() {
 
       expect(dartFunc['preserveExternalChanges'], isNull);
       expect(nodejsFunc['preserveExternalChanges'], isNull);
+    });
+
+    test('serviceAccountShorthand should preserve trailing @', () {
+      final dartFunc = _getEndpoint(dartManifest, 'serviceAccountShorthand')!;
+      final nodejsFunc = _getEndpoint(
+        nodejsManifest,
+        'serviceAccountShorthand',
+      )!;
+
+      expect(dartFunc['serviceAccountEmail'], equals('super-account@'));
+      expect(nodejsFunc['serviceAccountEmail'], equals('super-account@'));
     });
 
     test('callableFull should NOT have runtime-only options', () {

--- a/test/unit/builder_options_test.dart
+++ b/test/unit/builder_options_test.dart
@@ -80,6 +80,27 @@ void main() {
       expect(extractedOptions, containsPair('invoker', ['user@example.com']));
       expect(extractedOptions, containsPair('omit', false));
     });
+
+    test('preserves service account project-relative shorthand', () {
+      final options = _parseHttpsOptions('''
+void main() {
+  const options = const HttpsOptions(
+    serviceAccount: ServiceAccount('super-account@'),
+  );
+}
+''');
+
+      final endpoint = EndpointSpec(
+        name: 'helloWorld',
+        type: 'https',
+        options: options,
+      );
+
+      expect(
+        endpoint.extractOptions(),
+        containsPair('serviceAccount', 'super-account@'),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
closes #190 

Adding support for `@` shorthands in Service Account, adding documentation and tests for this feature.