### PR TITLE
fix: Fix builder extraction for factory-based function options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fix manifest generation for function options declared with named factories,
+  including `Memory.fromInt` in `CallableOptions`.
+
 ## 0.6.0
 
 - Add `runFunctions` as the primary API.

--- a/lib/src/builder/spec.dart
+++ b/lib/src/builder/spec.dart
@@ -196,31 +196,28 @@ class EndpointSpec {
   }
 
   bool _isResetOption(Expression expression) =>
-      expression is InstanceCreationExpression &&
       // `name` is preferred, but resolved/synthetic ASTs can represent
       // typedef-backed constructors without it.
-      (expression.constructorName.name?.name == 'reset' ||
+      _constructorName(expression) == 'reset' ||
+      (expression is InstanceCreationExpression &&
           expression.constructorName.toSource().endsWith('.reset'));
 
   /// Extracts Memory option value.
   Object? _extractMemory(Expression expression) {
     // Check if it's Memory.param() - generate CEL
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'param') {
+    if (_constructorName(expression) == 'param') {
       return _extractParamReference(expression);
     }
 
     // Check if it's Memory.expression() - generate CEL from expression
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'expression') {
+    if (_constructorName(expression) == 'expression') {
       return _extractCelExpression(
-        expression.argumentList.arguments.firstOrNull,
+        _extractCallArguments(expression)?.firstOrNull,
       );
     }
 
     // Check if it's Memory.reset()
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'reset') {
+    if (_constructorName(expression) == 'reset') {
       return null; // Reset means use default
     }
 
@@ -229,7 +226,10 @@ class EndpointSpec {
     final enumName = _extractEnumValueName(args?.firstOrNull);
     if (enumName != null) return _memoryOptionToInt(enumName);
 
-    return null;
+    return switch (args?.firstOrNull) {
+      final IntegerLiteral i => i.value,
+      _ => null,
+    };
   }
 
   /// Converts MemoryOption enum to integer value.
@@ -249,20 +249,17 @@ class EndpointSpec {
   /// Extracts CPU option value.
   Object? _extractCpu(Expression expression) {
     // Check if it's Cpu.gcfGen1()
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'gcfGen1') {
+    if (_constructorName(expression) == 'gcfGen1') {
       return 'gcf_gen1';
     }
 
     // Check if it's Cpu.param() - generate CEL
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'param') {
+    if (_constructorName(expression) == 'param') {
       return _extractParamReference(expression);
     }
 
     // Check if it's Cpu.reset()
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'reset') {
+    if (_constructorName(expression) == 'reset') {
       return null;
     }
 
@@ -278,8 +275,7 @@ class EndpointSpec {
   /// Extracts Region option value.
   Object? _extractRegion(Expression expression) {
     // Check if it's Region.param() - generate CEL
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'param') {
+    if (_constructorName(expression) == 'param') {
       return _extractParamReference(expression);
     }
 
@@ -342,11 +338,9 @@ class EndpointSpec {
       return expression.value;
     }
 
-    if (expression is InstanceCreationExpression) {
-      // Check if it's Option.param() - generate CEL
-      if (expression.constructorName.name?.name == 'param') {
-        return _extractParamReference(expression);
-      }
+    // Check if it's Option.param() - generate CEL
+    if (_constructorName(expression) == 'param') {
+      return _extractParamReference(expression);
     }
 
     // Extract literal: Option(123)
@@ -364,11 +358,9 @@ class EndpointSpec {
       return expression.stringValue;
     }
 
-    if (expression is InstanceCreationExpression) {
-      // Check if it's Option.param() - generate CEL
-      if (expression.constructorName.name?.name == 'param') {
-        return _extractParamReference(expression);
-      }
+    // Check if it's Option.param() - generate CEL
+    if (_constructorName(expression) == 'param') {
+      return _extractParamReference(expression);
     }
 
     // Extract literal: Option('value')
@@ -386,11 +378,9 @@ class EndpointSpec {
       return expression.value;
     }
 
-    if (expression is InstanceCreationExpression) {
-      // Check if it's Option.param() - generate CEL
-      if (expression.constructorName.name?.name == 'param') {
-        return _extractParamReference(expression);
-      }
+    // Check if it's Option.param() - generate CEL
+    if (_constructorName(expression) == 'param') {
+      return _extractParamReference(expression);
     }
 
     // Extract literal: Option(true)
@@ -436,12 +426,10 @@ class EndpointSpec {
   /// Extracts invoker list.
   Object? _extractInvoker(Expression expression) {
     // Check for special factories
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'public') {
+    if (_constructorName(expression) == 'public') {
       return ['public'];
     }
-    if (expression is InstanceCreationExpression &&
-        expression.constructorName.name?.name == 'private') {
+    if (_constructorName(expression) == 'private') {
       return ['private'];
     }
 
@@ -503,9 +491,9 @@ class EndpointSpec {
   }
 
   /// Extracts parameter reference and generates CEL expression.
-  String _extractParamReference(InstanceCreationExpression expression) {
-    final args = expression.argumentList.arguments;
-    if (args.isEmpty) return '{{ params.UNKNOWN }}';
+  String _extractParamReference(Expression expression) {
+    final args = _extractCallArguments(expression);
+    if (args == null || args.isEmpty) return '{{ params.UNKNOWN }}';
 
     final firstArg = args.first;
     if (firstArg is SimpleIdentifier) {
@@ -565,8 +553,14 @@ class EndpointSpec {
   ) => switch (expression) {
     InstanceCreationExpression(:final argumentList) => argumentList.arguments,
     FunctionExpressionInvocation(:final argumentList) => argumentList.arguments,
-    MethodInvocation(target: null, :final argumentList) =>
-      argumentList.arguments,
+    MethodInvocation(:final argumentList) => argumentList.arguments,
+    _ => null,
+  };
+
+  String? _constructorName(Expression expression) => switch (expression) {
+    InstanceCreationExpression(:final constructorName) =>
+      constructorName.name?.name,
+    MethodInvocation(:final methodName) => methodName.name,
     _ => null,
   };
 

--- a/lib/src/builder/spec.dart
+++ b/lib/src/builder/spec.dart
@@ -432,6 +432,9 @@ class EndpointSpec {
     if (_constructorName(expression) == 'private') {
       return ['private'];
     }
+    if (_constructorName(expression) == 'param') {
+      return [_extractParamReference(expression)];
+    }
 
     // Extract literal list
     final args = _extractCallArguments(expression);

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -699,6 +699,16 @@ void main(List<String> args) async {
       },
     );
 
+    // Callable with integer memory constructor.
+    firebase.https.onCall(
+      name: 'callableMemoryFromInt',
+      // ignore: non_const_argument_for_const_parameter
+      options: CallableOptions(memory: Memory.fromInt(1024)),
+      (request, response) async {
+        return CallableResult({'message': 'Callable with integer memory'});
+      },
+    );
+
     // HTTPS onRequest that crashes with sensitive data in the exception.
     // Used by E2E tests to verify errors are logged but NOT leaked to clients.
     firebase.https.onRequest(name: 'crashWithSecret', (request) async {

--- a/test/fixtures/nodejs_reference/index.js
+++ b/test/fixtures/nodejs_reference/index.js
@@ -603,6 +603,16 @@ exports.callableFull = onCall(
   }
 );
 
+// Callable with integer memory equivalent.
+exports.callableMemoryFromInt = onCall(
+  {
+    memory: "1GiB"
+  },
+  (request) => {
+    return { message: "Callable with integer memory" };
+  }
+);
+
 // HTTPS onRequest that crashes with sensitive data in the exception.
 // Used by E2E tests to verify errors are logged but NOT leaked to clients.
 exports.crashWithSecret = onRequest(

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -327,14 +327,14 @@ void main() {
 
       expect(
         dartEndpoints.keys.length,
-        equals(52),
+        equals(53),
         reason:
-            'Should discover 52 functions (6 Callable + 4 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
+            'Should discover 53 functions (7 Callable + 4 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
       );
       expect(
         nodejsEndpoints.keys.length,
-        equals(52),
-        reason: 'Node.js reference should also have 52 endpoints',
+        equals(53),
+        reason: 'Node.js reference should also have 53 endpoints',
       );
 
       // Verify both manifests have the same endpoints (normalized via
@@ -1844,6 +1844,16 @@ void main() {
 
       expect(dartFunc['heartbeatSeconds'], isNull);
       expect(nodejsFunc['heartbeatSeconds'], isNull);
+    });
+
+    test('callableMemoryFromInt should match Node.js memory manifest', () {
+      final dartFunc = _getEndpoint(dartManifest, 'callableMemoryFromInt')!;
+      final nodejsFunc = _getEndpoint(nodejsManifest, 'callableMemoryFromInt')!;
+
+      expect(dartFunc['callableTrigger'], isNotNull);
+      expect(nodejsFunc['callableTrigger'], isNotNull);
+      expect(dartFunc['availableMemoryMb'], equals(1024));
+      expect(nodejsFunc['availableMemoryMb'], equals(1024));
     });
 
     test('httpsGen1 should have gcf_gen1 CPU', () {

--- a/test/unit/builder_options_test.dart
+++ b/test/unit/builder_options_test.dart
@@ -20,6 +20,75 @@ import 'package:test/test.dart';
 
 void main() {
   group('EndpointSpec.extractOptions', () {
+    test('extracts callable memory from Memory.fromInt', () {
+      final options = _parseOptions('''
+void main() {
+  final options = new CallableOptions(
+    memory: Memory.fromInt(1024),
+  );
+}
+''', 'CallableOptions');
+
+      final endpoint = EndpointSpec(
+        name: 'callableFunction',
+        type: 'callable',
+        options: options,
+      );
+
+      expect(
+        endpoint.extractOptions(),
+        containsPair('availableMemoryMb', 1024),
+      );
+    });
+
+    test('extracts memory from Memory.fromOption factory', () {
+      final options = _parseOptions('''
+void main() {
+  final options = new HttpsOptions(
+    memory: Memory.fromOption(MemoryOption.gb2),
+  );
+}
+''', 'HttpsOptions');
+
+      final endpoint = EndpointSpec(
+        name: 'memoryFromOption',
+        type: 'https',
+        options: options,
+      );
+
+      expect(
+        endpoint.extractOptions(),
+        containsPair('availableMemoryMb', 2048),
+      );
+    });
+
+    test('extracts named factory options from method-style AST calls', () {
+      final options = _parseOptions('''
+void main() {
+  final options = new HttpsOptions(
+    cpu: Cpu.gcfGen1(),
+    invoker: Invoker.private(),
+    minInstances: DeployOption.param(minInstancesParam),
+  );
+}
+''', 'HttpsOptions');
+
+      final endpoint = EndpointSpec(
+        name: 'methodStyleFactories',
+        type: 'https',
+        options: options,
+        variableToParamName: {'minInstancesParam': 'MIN_INSTANCES'},
+      );
+      final extractedOptions = endpoint.extractOptions();
+
+      expect(extractedOptions, containsPair('cpu', 'gcf_gen1'));
+      expect(extractedOptions, containsPair('invoker', ['private']));
+      expect(
+        extractedOptions,
+        containsPair('minInstances', '{{ params.MIN_INSTANCES }}'),
+      );
+    });
+
     test('extracts region from DeployOption dot shorthand', () {
       final options = _parseHttpsOptions('''
 void main() {
@@ -84,8 +153,12 @@ void main() {
 }
 
 InstanceCreationExpression _parseHttpsOptions(String content) {
+  return _parseOptions(content, 'HttpsOptions');
+}
+
+InstanceCreationExpression _parseOptions(String content, String typeName) {
   final result = parseString(content: content);
-  final visitor = _InstanceCreationVisitor('HttpsOptions');
+  final visitor = _InstanceCreationVisitor(typeName);
 
   result.unit.accept(visitor);
 

--- a/test/unit/builder_options_test.dart
+++ b/test/unit/builder_options_test.dart
@@ -89,6 +89,28 @@ void main() {
       );
     });
 
+    test('extracts invoker from Invoker.param', () {
+      final options = _parseOptions('''
+void main() {
+  final options = new HttpsOptions(
+    invoker: Invoker.param(invokerParam),
+  );
+}
+''', 'HttpsOptions');
+
+      final endpoint = EndpointSpec(
+        name: 'invokerParamFunction',
+        type: 'https',
+        options: options,
+        variableToParamName: {'invokerParam': 'INVOKER'},
+      );
+
+      expect(
+        endpoint.extractOptions(),
+        containsPair('invoker', ['{{ params.INVOKER }}']),
+      );
+    });
+
     test('extracts region from DeployOption dot shorthand', () {
       final options = _parseHttpsOptions('''
 void main() {


### PR DESCRIPTION
fixes #191

Fixes manifest generation for function options declared with named factories, including `Memory.fromInt` in `CallableOptions`.

Also adds regression coverage against the Node.js reference manifest. 