### PR TITLE
feat: add support for cascade style declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Fix manifest generation for function options declared with named factories,
   including `Memory.fromInt` in `CallableOptions`.
+- Fix manifest discovery for functions registered with cascade syntax (e.g.
+  `firebase.https..onCall(...)..onCall(...)`), which were previously omitted
+  from `functions.yaml`.
+- Emit a build warning when no functions are discovered instead of silently
+  writing an endpoint-less `functions.yaml`.
 
 ## 0.6.0
 

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -91,6 +91,18 @@ class _SpecBuilder implements Builder {
       allEndpoints.addAll(visitor.endpoints);
     }
 
+    // Surface a clear warning instead of silently emitting an endpoint-less
+    // manifest, which the Firebase CLI only reports as a generic
+    // "Failed to parse build specification" error.
+    if (allEndpoints.isEmpty) {
+      log.warning(
+        'No Firebase Functions were discovered, so the generated '
+        'functions.yaml has no endpoints. Make sure your functions are '
+        'registered inside the runFunctions callback, for example:\n'
+        "  firebase.https.onRequest(name: 'myFn', handler);",
+      );
+    }
+
     // Generate YAML from collected data
     final yamlContent = generateManifestYaml(allParams, allEndpoints);
 
@@ -303,25 +315,25 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    super.visitMethodInvocation(node);
-    final target = node.target;
     final methodName = node.methodName.name;
+    // Use `realTarget` so cascaded invocations are resolved correctly. For a
+    // cascade such as `firebase.https..onCall(...)..onCall(...)`, each section's
+    // `target` is null while `realTarget` points at the cascade receiver
+    // (`firebase.https`). Regular invocations report the same value for both.
+    final target = node.realTarget;
     if (target != null) {
       // Check against all namespaces
       for (final namespace in namespaces) {
-        if (namespace.isNamespace(target)) {
-          if (namespace.matches(methodName)) {
-            namespace.extractor(node, methodName);
-            // Found a match, no need to check other namespaces for this node
-            return;
-          }
+        if (namespace.isNamespace(target) && namespace.matches(methodName)) {
+          namespace.extractor(node, methodName);
+          // Found a match, no need to check other namespaces for this node.
+          break;
         }
       }
-    } else {
-      // Check for parameter definitions (top-level function calls with no target)
-      if (_isParamDefinition(methodName)) {
-        _extractParameterFromMethod(node, methodName);
-      }
+    } else if (_isParamDefinition(methodName)) {
+      // Check for parameter definitions (top-level function calls with no
+      // target).
+      _extractParameterFromMethod(node, methodName);
     }
 
     super.visitMethodInvocation(node);

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -324,7 +324,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     if (target != null) {
       // Check against all namespaces
       for (final namespace in namespaces) {
-        if (namespace.isNamespace(target) && namespace.matches(methodName)) {
+        if (namespace.matches(methodName) && namespace.isNamespace(target)) {
           namespace.extractor(node, methodName);
           // Found a match, no need to check other namespaces for this node.
           break;

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -174,6 +174,18 @@ void main(List<String> args) async {
       },
     );
 
+    // Cascade-style registration (issue #196): both endpoints must be
+    // discovered even though each section's `target` is null in the AST.
+    firebase.https
+      ..onRequest(
+        name: 'cascadeFirst',
+        (request) async => Response.ok('cascade first'),
+      )
+      ..onRequest(
+        name: 'cascadeSecond',
+        (request) async => Response.ok('cascade second'),
+      );
+
     // Pub/Sub trigger example
     firebase.pubsub.onMessagePublished(topic: 'my-topic', (event) async {
       final message = event.data;

--- a/test/fixtures/nodejs_reference/index.js
+++ b/test/fixtures/nodejs_reference/index.js
@@ -159,6 +159,16 @@ exports.configuredEndpoint = onRequest(
   }
 );
 
+// Counterparts to the Dart cascade-syntax registrations (issue #196). Node has
+// no cascade equivalent; these keep the reference endpoint set aligned.
+exports.cascadeFirst = onRequest((request, response) => {
+  response.send("cascade first");
+});
+
+exports.cascadeSecond = onRequest((request, response) => {
+  response.send("cascade second");
+});
+
 // Pub/Sub trigger example
 exports.onMessagePublished_mytopic = onMessagePublished(
   "my-topic",

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -327,14 +327,14 @@ void main() {
 
       expect(
         dartEndpoints.keys.length,
-        equals(53),
+        equals(55),
         reason:
-            'Should discover 53 functions (7 Callable + 4 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
+            'Should discover 55 functions (7 Callable + 6 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options)',
       );
       expect(
         nodejsEndpoints.keys.length,
-        equals(53),
-        reason: 'Node.js reference should also have 53 endpoints',
+        equals(55),
+        reason: 'Node.js reference should also have 55 endpoints',
       );
 
       // Verify both manifests have the same endpoints (normalized via
@@ -448,6 +448,19 @@ void main() {
       expect(nodejsFunc['platform'], equals('gcfv2'));
       expect(dartFunc['httpsTrigger'], isNotNull);
       expect(nodejsFunc['httpsTrigger'], isNotNull);
+    });
+
+    test('should discover functions registered with cascade syntax', () {
+      // Regression test for issue #196: cascaded registrations such as
+      // `firebase.https..onRequest(...)..onRequest(...)` were silently dropped
+      // because each section's AST `target` is null.
+      final first = _getEndpoint(dartManifest, 'cascadeFirst');
+      final second = _getEndpoint(dartManifest, 'cascadeSecond');
+
+      expect(first, isNotNull, reason: 'First cascade section must be found');
+      expect(second, isNotNull, reason: 'Second cascade section must be found');
+      expect(first!['httpsTrigger'], isNotNull);
+      expect(second!['httpsTrigger'], isNotNull);
     });
 
     test('should have correct CEL expression for minInstances param', () {


### PR DESCRIPTION
closes #196 by adding support to cascade style declarations.
Adds a warning if no functions have been discovered during manifest generation.