### PR TITLE
fix: correct path routing for Firebase Hosting rewrites in emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log
 
 # Firebase
 .firebase/
+.firebaserc
 firebase-debug.log
 firestore-debug.log
 ui-debug.log

--- a/example/hosting/bin/server.dart
+++ b/example/hosting/bin/server.dart
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:firebase_functions/firebase_functions.dart';
+
+void main() async {
+  await runFunctions((firebase) {
+    // An onRequest function used as a backend for Firebase Hosting rewrites.
+    // All requests to the hosted site are forwarded to this function, which
+    // handles routing based on the request path.
+    //
+    // firebase.json configures the rewrite:
+    //   { "source": "**", "run": { "serviceId": "app", "region": "us-central1" } }
+    firebase.https.onRequest(
+      name: 'app',
+      options: const HttpsOptions(invoker: Invoker.public()),
+      (request) async {
+        final path = request.requestedUri.path;
+        return switch (path) {
+          '/' => Response.ok('Home page'),
+          '/about' => Response.ok('About page'),
+          _ => Response.notFound('Not found: $path'),
+        };
+      },
+    );
+  });
+}

--- a/example/hosting/firebase.json
+++ b/example/hosting/firebase.json
@@ -23,7 +23,7 @@
       "port": 5001
     },
     "hosting": {
-      "port": 5000
+      "port": 5002
     },
     "ui": {
       "enabled": true

--- a/example/hosting/firebase.json
+++ b/example/hosting/firebase.json
@@ -1,0 +1,33 @@
+{
+  "functions": [
+    {
+      "source": ".",
+      "codebase": "default",
+      "runtime": "dart3"
+    }
+  ],
+  "hosting": {
+    "public": "public",
+    "rewrites": [
+      {
+        "source": "**",
+        "run": {
+          "serviceId": "app",
+          "region": "us-central1"
+        }
+      }
+    ]
+  },
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "hosting": {
+      "port": 5000
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}

--- a/example/hosting/pubspec.yaml
+++ b/example/hosting/pubspec.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: hosting_example
+description: Firebase Hosting rewrites example for Firebase Functions for Dart
+publish_to: none
+
+resolution: workspace
+
+environment:
+  sdk: ^3.7.0
+
+dependencies:
+  firebase_functions: ^0.7.0-wip
+
+dev_dependencies:
+  build_runner: ^2.10.5
+  lints: ^6.0.0

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -348,14 +348,17 @@ FutureOr<Response> _routeByPath(
     final wrappedHandler = withInit(function.handler);
     final response = await wrappedHandler(handlerRequest);
     if (function.allowedOrigins != null) {
-      return _applyCorsHeaders(handlerRequest, response, function.allowedOrigins!);
+      return _applyCorsHeaders(
+        handlerRequest,
+        response,
+        function.allowedOrigins!,
+      );
     }
     return response;
   }
 
   // No matching function found.
-  final notFoundName = xFirebaseFunction ??
-      (parts.isNotEmpty ? parts[0] : '');
+  final notFoundName = xFirebaseFunction ?? (parts.isNotEmpty ? parts[0] : '');
   return Response.notFound(
     'Function not found: $notFoundName\n'
     'Available functions: ${functions.map((f) => f.name).join(", ")}',
@@ -609,7 +612,6 @@ Request _withOriginalPath(Request request, String originalPath) {
     context: request.context,
   );
 }
-
 
 /// Handles the /__/quitquitquit graceful shutdown endpoint.
 ///

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -203,7 +203,7 @@ FutureOr<Response> _routeRequest(
   }
 
   // Shared process mode (development): Route by path
-  return _routeByPath(request, functions, requestPath);
+  return routeByPath(request, functions, requestPath);
 }
 
 /// Routes request to the function specified by FUNCTION_TARGET.
@@ -257,8 +257,8 @@ FutureOr<Response> _routeToTargetFunction(
   return response;
 }
 
-/// Routes request by path matching (development/shared process mode).
-FutureOr<Response> _routeByPath(
+@visibleForTesting
+FutureOr<Response> routeByPath(
   Request request,
   List<FirebaseFunctionDeclaration> functions,
   String requestPath,
@@ -281,15 +281,16 @@ FutureOr<Response> _routeByPath(
     currentRequest = reconstructedRequest;
   }
 
-  // Not a CloudEvent, try path-based routing for HTTPS functions
-  // Extract the function name from the path (/{functionName})
-  // The firebase-tools emulator sets X-Firebase-Function header for Dart runtimes
-  var functionName = _extractFunctionName(requestPath);
+  // Not a CloudEvent, try path-based routing for HTTPS functions.
+  // Prioritize the X-Firebase-Function header set by firebase-tools for hosting
+  // rewrites, then fall back to extracting the function name from the path.
+  final isHostingRewrite =
+      currentRequest.headers.containsKey('x-firebase-function');
+  var functionName =
+      currentRequest.headers['x-firebase-function'] ??
+      extractFunctionName(requestPath);
 
-  // Fallback: Check for X-Firebase-Function header set by firebase-tools
-  if (functionName.isEmpty) {
-    functionName = currentRequest.headers['x-firebase-function'] ?? '';
-  }
+  if (functionName.isEmpty) functionName = extractFunctionName(requestPath);
 
   // Try to find a matching function by name
   for (final function in functions) {
@@ -306,11 +307,19 @@ FutureOr<Response> _routeByPath(
         continue;
       }
 
+      // Strip the routing prefix so handlers see the original request path,
+      // matching production Cloud Run behaviour.
+      final handlerRequest = _withOriginalPath(
+        currentRequest,
+        requestPath,
+        isHostingRewrite: isHostingRewrite,
+      );
+
       final wrappedHandler = withInit(function.handler);
-      final response = await wrappedHandler(currentRequest);
+      final response = await wrappedHandler(handlerRequest);
       if (function.allowedOrigins != null) {
         return _applyCorsHeaders(
-          currentRequest,
+          handlerRequest,
           response,
           function.allowedOrigins!,
         );
@@ -560,6 +569,52 @@ Future<(Request, FirebaseFunctionDeclaration?)> _tryMatchCloudEventFunction(
   }
 }
 
+/// Returns the original request path by stripping the routing prefix added by
+/// the emulator. For hosting rewrites the prefix is `/{functionName}`; for
+/// direct emulator calls it is `/{project}/{region}/{functionName}`.
+String _originalRequestPath(
+  String requestPath, {
+  required bool isHostingRewrite,
+}) {
+  var path = requestPath;
+  if (path.startsWith('/')) path = path.substring(1);
+  if (path.endsWith('/')) path = path.substring(0, path.length - 1);
+  if (path.isEmpty) return '/';
+
+  final parts = path.split('/');
+
+  // Direct emulator call: /{project}/{region}/{functionName}[/{rest}]
+  if (!isHostingRewrite && parts.length >= 3) {
+    final rest = parts.sublist(3).join('/');
+    return rest.isEmpty ? '/' : '/$rest';
+  }
+
+  // Hosting rewrite: /{functionName}[/{rest}]
+  final rest = parts.sublist(1).join('/');
+  return rest.isEmpty ? '/' : '/$rest';
+}
+
+/// Creates a copy of [request] with the original path set on its `requestedUri`.
+/// Returns [request] unchanged when the path is already correct.
+Request _withOriginalPath(
+  Request request,
+  String requestPath, {
+  required bool isHostingRewrite,
+}) {
+  final original = _originalRequestPath(
+    requestPath,
+    isHostingRewrite: isHostingRewrite,
+  );
+  if (request.requestedUri.path == original) return request;
+  return Request(
+    request.method,
+    request.requestedUri.replace(path: original),
+    headers: request.headers,
+    body: request.read(),
+    context: request.context,
+  );
+}
+
 /// Extracts the function name from a request path.
 ///
 /// Handles different path formats:
@@ -569,7 +624,8 @@ Future<(Request, FirebaseFunctionDeclaration?)> _tryMatchCloudEventFunction(
 ///
 /// For event triggers, the triggerId may include region prefix like "us-central1-functionName"
 /// We need to extract just the function name part.
-String _extractFunctionName(String requestPath) {
+@visibleForTesting
+String extractFunctionName(String requestPath) {
   // Remove leading and trailing slashes
   var path = requestPath;
   if (path.startsWith('/')) {
@@ -600,21 +656,17 @@ String _extractFunctionName(String requestPath) {
     }
   }
 
-  // HTTPS path: {project}/{region}/{functionName} or just {functionName}
+  // HTTPS path: {project}/{region}/{functionName}[/{rest}] or {functionName}[/{rest}]
   final parts = path.split('/');
 
-  // If path has 3 parts, assume {project}/{region}/{functionName}
-  if (parts.length == 3) {
+  // 3+ parts: /{project}/{region}/{functionName}[/{rest}] — function name is always at index 2.
+  if (parts.length >= 3) {
     return parts[2];
   }
 
-  // If path has 1 part, it's just {functionName}
-  if (parts.length == 1) {
-    return parts[0];
-  }
-
-  // Return the last part as function name
-  return parts.isNotEmpty ? parts.last : path;
+  // 1–2 parts: /{functionName}[/{rest}] — hosting rewrites prepend the function
+  // name to the original path, so the function name is always the first segment.
+  return parts.isNotEmpty ? parts[0] : '';
 }
 
 /// Handles the /__/quitquitquit graceful shutdown endpoint.

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -119,6 +119,13 @@ Future<void> runFunctions(
   });
 }
 
+/// Creates a shelf [Handler] for [firebase] without starting an HTTP server.
+///
+/// Use in tests to exercise the full routing pipeline without binding a port.
+@visibleForTesting
+Handler createTestHandler(Firebase firebase) =>
+    (request) => _routeRequest(request, firebase, firebase.$env);
+
 /// CORS middleware for emulator mode.
 Handler _corsMiddleware(Handler innerHandler) => (request) {
   // Handle preflight OPTIONS requests
@@ -203,7 +210,7 @@ FutureOr<Response> _routeRequest(
   }
 
   // Shared process mode (development): Route by path
-  return routeByPath(request, functions, requestPath);
+  return _routeByPath(request, functions, requestPath);
 }
 
 /// Routes request to the function specified by FUNCTION_TARGET.
@@ -257,8 +264,7 @@ FutureOr<Response> _routeToTargetFunction(
   return response;
 }
 
-@visibleForTesting
-FutureOr<Response> routeByPath(
+FutureOr<Response> _routeByPath(
   Request request,
   List<FirebaseFunctionDeclaration> functions,
   String requestPath,
@@ -281,56 +287,77 @@ FutureOr<Response> routeByPath(
     currentRequest = reconstructedRequest;
   }
 
-  // Not a CloudEvent, try path-based routing for HTTPS functions.
-  // Prioritize the X-Firebase-Function header set by firebase-tools for hosting
-  // rewrites, then fall back to extracting the function name from the path.
-  final isHostingRewrite =
-      currentRequest.headers.containsKey('x-firebase-function');
-  var functionName =
-      currentRequest.headers['x-firebase-function'] ??
-      extractFunctionName(requestPath);
+  // Not a CloudEvent — route to a registered HTTPS function.
+  //
+  // The functions emulator always forwards to the Dart process with the path
+  // stripped to /{functionName}[/{rest}], so parts[0] is the function name.
+  // For direct calls that bypass the emulator, the format is
+  // /{project}/{region}/{functionName}[/{rest}], so parts[2] is the function
+  // name. We resolve the ambiguity by checking each registered function name
+  // against the path segments rather than guessing from segment count.
+  var normalPath = requestPath;
+  if (normalPath.startsWith('/')) normalPath = normalPath.substring(1);
+  if (normalPath.endsWith('/')) {
+    normalPath = normalPath.substring(0, normalPath.length - 1);
+  }
+  final parts = normalPath.isEmpty ? <String>[] : normalPath.split('/');
 
-  if (functionName.isEmpty) functionName = extractFunctionName(requestPath);
+  // X-Firebase-Function header is set by firebase-tools for hosting rewrites.
+  final xFirebaseFunction = currentRequest.headers['x-firebase-function'];
 
-  // Try to find a matching function by name
   for (final function in functions) {
-    if (functionName == function.name) {
-      if (currentRequest.method.toUpperCase() == 'OPTIONS' &&
-          function.allowedOrigins != null) {
-        return _buildOptionsCorsResponse(
-          currentRequest,
-          function.allowedOrigins!,
-        );
-      }
+    String? originalPath;
 
-      if (!function.external && currentRequest.method.toUpperCase() != 'POST') {
-        continue;
+    if (xFirebaseFunction != null) {
+      // Header explicitly identifies the function; use it.
+      if (function.name != xFirebaseFunction) continue;
+      if (parts.isNotEmpty && parts[0] == function.name) {
+        final rest = parts.sublist(1).join('/');
+        originalPath = rest.isEmpty ? '/' : '/$rest';
+      } else {
+        originalPath = '/';
       }
-
-      // Strip the routing prefix so handlers see the original request path,
-      // matching production Cloud Run behaviour.
-      final handlerRequest = _withOriginalPath(
-        currentRequest,
-        requestPath,
-        isHostingRewrite: isHostingRewrite,
-      );
-
-      final wrappedHandler = withInit(function.handler);
-      final response = await wrappedHandler(handlerRequest);
-      if (function.allowedOrigins != null) {
-        return _applyCorsHeaders(
-          handlerRequest,
-          response,
-          function.allowedOrigins!,
-        );
-      }
-      return response;
+    } else if (parts.isNotEmpty && parts[0] == function.name) {
+      // /{functionName}[/{rest}] — emulator routing
+      final rest = parts.sublist(1).join('/');
+      originalPath = rest.isEmpty ? '/' : '/$rest';
+    } else if (parts.length >= 3 && parts[2] == function.name) {
+      // /{project}/{region}/{functionName}[/{rest}] — direct call
+      final rest = parts.length > 3 ? parts.sublist(3).join('/') : '';
+      originalPath = rest.isEmpty ? '/' : '/$rest';
+    } else {
+      continue;
     }
+
+    if (currentRequest.method.toUpperCase() == 'OPTIONS' &&
+        function.allowedOrigins != null) {
+      return _buildOptionsCorsResponse(
+        currentRequest,
+        function.allowedOrigins!,
+      );
+    }
+
+    if (!function.external && currentRequest.method.toUpperCase() != 'POST') {
+      continue;
+    }
+
+    // Reconstruct the request with the original path so handlers see the same
+    // path they would in production Cloud Run.
+    final handlerRequest = _withOriginalPath(currentRequest, originalPath);
+
+    final wrappedHandler = withInit(function.handler);
+    final response = await wrappedHandler(handlerRequest);
+    if (function.allowedOrigins != null) {
+      return _applyCorsHeaders(handlerRequest, response, function.allowedOrigins!);
+    }
+    return response;
   }
 
-  // No matching function found
+  // No matching function found.
+  final notFoundName = xFirebaseFunction ??
+      (parts.isNotEmpty ? parts[0] : '');
   return Response.notFound(
-    'Function not found: $functionName\n'
+    'Function not found: $notFoundName\n'
     'Available functions: ${functions.map((f) => f.name).join(", ")}',
   );
 }
@@ -569,105 +596,20 @@ Future<(Request, FirebaseFunctionDeclaration?)> _tryMatchCloudEventFunction(
   }
 }
 
-/// Returns the original request path by stripping the routing prefix added by
-/// the emulator. For hosting rewrites the prefix is `/{functionName}`; for
-/// direct emulator calls it is `/{project}/{region}/{functionName}`.
-String _originalRequestPath(
-  String requestPath, {
-  required bool isHostingRewrite,
-}) {
-  var path = requestPath;
-  if (path.startsWith('/')) path = path.substring(1);
-  if (path.endsWith('/')) path = path.substring(0, path.length - 1);
-  if (path.isEmpty) return '/';
-
-  final parts = path.split('/');
-
-  // Direct emulator call: /{project}/{region}/{functionName}[/{rest}]
-  if (!isHostingRewrite && parts.length >= 3) {
-    final rest = parts.sublist(3).join('/');
-    return rest.isEmpty ? '/' : '/$rest';
-  }
-
-  // Hosting rewrite: /{functionName}[/{rest}]
-  final rest = parts.sublist(1).join('/');
-  return rest.isEmpty ? '/' : '/$rest';
-}
-
-/// Creates a copy of [request] with the original path set on its `requestedUri`.
-/// Returns [request] unchanged when the path is already correct.
-Request _withOriginalPath(
-  Request request,
-  String requestPath, {
-  required bool isHostingRewrite,
-}) {
-  final original = _originalRequestPath(
-    requestPath,
-    isHostingRewrite: isHostingRewrite,
-  );
-  if (request.requestedUri.path == original) return request;
+/// Creates a copy of [request] with [originalPath] set on its `requestedUri`
+/// so that handlers see the original client path rather than the routing prefix
+/// added by the emulator. Returns [request] unchanged if the path already matches.
+Request _withOriginalPath(Request request, String originalPath) {
+  if (request.requestedUri.path == originalPath) return request;
   return Request(
     request.method,
-    request.requestedUri.replace(path: original),
+    request.requestedUri.replace(path: originalPath),
     headers: request.headers,
     body: request.read(),
     context: request.context,
   );
 }
 
-/// Extracts the function name from a request path.
-///
-/// Handles different path formats:
-/// - Event triggers: /functions/projects/{project}/triggers/{triggerId} -> {entryPoint}
-/// - HTTPS functions: /{functionName} -> {functionName}
-/// - HTTPS with project/region: /{project}/{region}/{functionName} -> {functionName}
-///
-/// For event triggers, the triggerId may include region prefix like "us-central1-functionName"
-/// We need to extract just the function name part.
-@visibleForTesting
-String extractFunctionName(String requestPath) {
-  // Remove leading and trailing slashes
-  var path = requestPath;
-  if (path.startsWith('/')) {
-    path = path.substring(1);
-  }
-  if (path.endsWith('/')) {
-    path = path.substring(0, path.length - 1);
-  }
-
-  // Event trigger path: functions/projects/{project}/triggers/{triggerId}
-  if (path.startsWith('functions/projects/')) {
-    final parts = path.split('/');
-    if (parts.length >= 5 && parts[3] == 'triggers') {
-      // Extract trigger ID from: functions/projects/{project}/triggers/{triggerId}
-      var triggerId = parts[4];
-
-      // Firebase-tools prefixes trigger IDs with region (e.g., "us-central1-functionName")
-      // and may add suffixes (e.g., "us-central1-functionName-0")
-      // We need to strip these to get the actual function entry point name.
-
-      // Remove region prefix (e.g., "us-central1-", "europe-west1-")
-      triggerId = triggerId.replaceFirst(RegExp(r'^[a-z]+-[a-z]+\d+-'), '');
-
-      // Remove numeric suffix (e.g., "-0", "-1")
-      triggerId = triggerId.replaceFirst(RegExp(r'-\d+$'), '');
-
-      return triggerId;
-    }
-  }
-
-  // HTTPS path: {project}/{region}/{functionName}[/{rest}] or {functionName}[/{rest}]
-  final parts = path.split('/');
-
-  // 3+ parts: /{project}/{region}/{functionName}[/{rest}] — function name is always at index 2.
-  if (parts.length >= 3) {
-    return parts[2];
-  }
-
-  // 1–2 parts: /{functionName}[/{rest}] — hosting rewrites prepend the function
-  // name to the original path, so the function name is always the first segment.
-  return parts.isNotEmpty ? parts[0] : '';
-}
 
 /// Handles the /__/quitquitquit graceful shutdown endpoint.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ environment:
   sdk: ^3.9.0
 
 workspace:
+  - example/hosting
   - example/https
   - example/firestore
   - example/pubsub

--- a/test/e2e/e2e_test.dart
+++ b/test/e2e/e2e_test.dart
@@ -25,12 +25,14 @@ import 'helpers/auth_client.dart';
 import 'helpers/database_client.dart';
 import 'helpers/emulator.dart';
 import 'helpers/firestore_client.dart';
+import 'helpers/hosting_client.dart';
 import 'helpers/http_client.dart';
 import 'helpers/pubsub_client.dart';
 import 'helpers/storage_client.dart';
 import 'helpers/test_client_base.dart';
 import 'tests/database_tests.dart';
 import 'tests/firestore_tests.dart';
+import 'tests/hosting_tests.dart';
 import 'tests/https_oncall_tests.dart';
 import 'tests/https_onrequest_tests.dart';
 import 'tests/identity_tests.dart';
@@ -42,6 +44,7 @@ import 'tests/storage_tests.dart';
 void main() {
   EmulatorHelper? emulator;
   FunctionsHttpClient? client;
+  HostingHttpClient? hostingClient;
   PubSubClient? pubsubClient;
   FirestoreClient? firestoreClient;
   DatabaseClient? databaseClient;
@@ -95,6 +98,9 @@ void main() {
     // Create HTTP client
     client = FunctionsHttpClient(emulator!.functionsUrl);
 
+    // Create Hosting client
+    hostingClient = HostingHttpClient(emulator!.hostingUrl);
+
     // Create Pub/Sub client
     pubsubClient = PubSubClient(emulator!.pubsubUrl, 'demo-test');
 
@@ -127,6 +133,7 @@ void main() {
     try {
       for (final client in <TestClientBase>[
         ?client,
+        ?hostingClient,
         ?pubsubClient,
         ?firestoreClient,
         ?databaseClient,
@@ -146,6 +153,7 @@ void main() {
 
   // Run all test groups (pass closures to defer value access)
   runHttpsOnRequestTests(() => client!, () => emulator!);
+  runHostingTests(() => hostingClient!);
   runHttpsOnCallTests(() => client!);
   runIntegrationTests(() => examplePath);
   runPubSubTests(() => examplePath, () => pubsubClient!, () => emulator!);

--- a/test/e2e/helpers/emulator.dart
+++ b/test/e2e/helpers/emulator.dart
@@ -21,6 +21,7 @@ class EmulatorHelper {
   EmulatorHelper({
     required this.projectPath,
     this.functionsPort = 5001,
+    this.hostingPort = 5003,
     this.pubsubPort = 8085,
     this.firestorePort = 8080,
     this.databasePort = 9000,
@@ -31,6 +32,7 @@ class EmulatorHelper {
   Process? _process;
   final String projectPath;
   final int functionsPort;
+  final int hostingPort;
   final int pubsubPort;
   final int firestorePort;
   final int databasePort;
@@ -71,7 +73,7 @@ class EmulatorHelper {
         ...baseArgs,
         'emulators:start',
         '--only',
-        'functions,pubsub,firestore,database,auth,storage',
+        'functions,hosting,pubsub,firestore,database,auth,storage',
         '--project',
         'demo-test',
         '--non-interactive',
@@ -291,6 +293,9 @@ class EmulatorHelper {
   /// Gets the base URL for the functions emulator.
   String get functionsUrl =>
       'http://localhost:$functionsPort/demo-test/us-central1';
+
+  /// Gets the base URL for the hosting emulator.
+  String get hostingUrl => 'http://localhost:$hostingPort';
 
   /// Gets the base URL for the Pub/Sub emulator.
   String get pubsubUrl => 'http://localhost:$pubsubPort';

--- a/test/e2e/helpers/hosting_client.dart
+++ b/test/e2e/helpers/hosting_client.dart
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:http/http.dart' as http;
+
+import 'test_client_base.dart';
+
+/// HTTP client for making requests to the Firebase Hosting emulator.
+final class HostingHttpClient extends TestClientBase {
+  HostingHttpClient(super.baseUrl);
+
+  Future<http.Response> get(String path) async {
+    final url = Uri.parse('$baseUrl$path');
+    print('GET $url');
+    return client.get(url);
+  }
+}

--- a/test/e2e/tests/hosting_tests.dart
+++ b/test/e2e/tests/hosting_tests.dart
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:test/test.dart';
+
+import '../helpers/hosting_client.dart';
+
+/// Hosting rewrite test group.
+///
+/// Verifies that the hosting emulator correctly forwards requests to the Dart
+/// function and that handlers receive the original request path, not the
+/// routing prefix added by the emulator.
+void runHostingTests(HostingHttpClient Function() getClient) {
+  group('Hosting rewrites', () {
+    late HostingHttpClient client;
+
+    setUpAll(() {
+      client = getClient();
+    });
+
+    test('root path is passed correctly to handler', () async {
+      final response = await client.get('/');
+      expect(response.statusCode, equals(200));
+      expect(response.body, equals('/'));
+    });
+
+    test('sub-path is passed correctly to handler', () async {
+      final response = await client.get('/about');
+      expect(response.statusCode, equals(200));
+      expect(response.body, equals('/about'));
+    });
+
+    test('deep path is passed correctly to handler', () async {
+      final response = await client.get('/a/b/c');
+      expect(response.statusCode, equals(200));
+      expect(response.body, equals('/a/b/c'));
+    });
+  });
+}

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -79,22 +79,26 @@ void runHttpsOnRequestTests(
       expect(response.statusCode, equals(404));
     });
 
-    test('handles multiple concurrent requests', () async {
-      // Reduced from 10 to 5 requests to avoid CI timeout issues
-      // The emulator spawns separate workers which can be slow in CI
-      print('Making 5 concurrent requests...');
-      final futures = <Future<void>>[];
+    test(
+      'handles multiple concurrent requests',
+      () async {
+        // Reduced from 10 to 5 requests to avoid CI timeout issues
+        // The emulator spawns separate workers which can be slow in CI
+        print('Making 5 concurrent requests...');
+        final futures = <Future<void>>[];
 
-      for (var i = 0; i < 5; i++) {
-        futures.add(() async {
-          final response = await client.get('helloworld');
-          expect(response.statusCode, equals(200));
-          expect(response.body, contains('Hello from Dart Functions!'));
-        }());
-      }
+        for (var i = 0; i < 5; i++) {
+          futures.add(() async {
+            final response = await client.get('helloworld');
+            expect(response.statusCode, equals(200));
+            expect(response.body, contains('Hello from Dart Functions!'));
+          }());
+        }
 
-      await Future.wait(futures);
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        await Future.wait(futures);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
 
     test('function is discoverable via emulator', () async {
       print('GET ${client.baseUrl}/helloworld');

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -79,26 +79,22 @@ void runHttpsOnRequestTests(
       expect(response.statusCode, equals(404));
     });
 
-    test(
-      'handles multiple concurrent requests',
-      () async {
-        // Reduced from 10 to 5 requests to avoid CI timeout issues
-        // The emulator spawns separate workers which can be slow in CI
-        print('Making 5 concurrent requests...');
-        final futures = <Future<void>>[];
+    test('handles multiple concurrent requests', () async {
+      // Reduced from 10 to 5 requests to avoid CI timeout issues
+      // The emulator spawns separate workers which can be slow in CI
+      print('Making 5 concurrent requests...');
+      final futures = <Future<void>>[];
 
-        for (var i = 0; i < 5; i++) {
-          futures.add(() async {
-            final response = await client.get('helloworld');
-            expect(response.statusCode, equals(200));
-            expect(response.body, contains('Hello from Dart Functions!'));
-          }());
-        }
+      for (var i = 0; i < 5; i++) {
+        futures.add(() async {
+          final response = await client.get('helloworld');
+          expect(response.statusCode, equals(200));
+          expect(response.body, contains('Hello from Dart Functions!'));
+        }());
+      }
 
-        await Future.wait(futures);
-      },
-      timeout: const Timeout(Duration(seconds: 60)),
-    );
+      await Future.wait(futures);
+    }, timeout: const Timeout(Duration(seconds: 60)));
 
     test('function is discoverable via emulator', () async {
       print('GET ${client.baseUrl}/helloworld');

--- a/test/fixtures/dart_reference/bin/server.dart
+++ b/test/fixtures/dart_reference/bin/server.dart
@@ -816,6 +816,13 @@ void main(List<String> args) async {
       (request) async => Response.ok('Cross-file options'),
     );
 
+    // Used by E2E hosting rewrite tests to verify the correct request path
+    // is passed to the handler after the hosting emulator strips the routing prefix.
+    firebase.https.onRequest(
+      name: 'echoPath',
+      (request) async => Response.ok(request.requestedUri.path),
+    );
+
     print('Functions registered successfully!');
   });
 }

--- a/test/fixtures/dart_reference/firebase.json
+++ b/test/fixtures/dart_reference/firebase.json
@@ -6,9 +6,24 @@
       "runtime": "dart3"
     }
   ],
+  "hosting": {
+    "public": "public",
+    "rewrites": [
+      {
+        "source": "**",
+        "run": {
+          "serviceId": "echopath",
+          "region": "us-central1"
+        }
+      }
+    ]
+  },
   "emulators": {
     "functions": {
       "port": 5001
+    },
+    "hosting": {
+      "port": 5003
     },
     "auth": {
       "port": 9099

--- a/test/fixtures/nodejs_reference/index.js
+++ b/test/fixtures/nodejs_reference/index.js
@@ -685,6 +685,14 @@ exports.httpsWithSecrets = onRequest(
   }
 );
 
+// Used by E2E hosting rewrite tests to verify the correct request path
+// is passed to the handler after the hosting emulator strips the routing prefix.
+exports.echoPath = onRequest(
+  (request, response) => {
+    response.send(request.path);
+  }
+);
+
 // Pub/Sub with options
 exports.onMessagePublished_optionstopic = onMessagePublished(
   {

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -353,14 +353,14 @@ void main() {
 
       expect(
         dartEndpoints.keys,
-        hasLength(57),
+        hasLength(58),
         reason:
-            'Should discover 57 functions (7 Callable + 7 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options + 1 Secrets)',
+            'Should discover 58 functions (7 Callable + 7 HTTPS + 1 Pub/Sub + 5 Firestore + 4 Firestore WithAuthContext + 5 Database + 3 Alerts + 4 Identity + 1 Remote Config + 4 Storage + 2 Eventarc + 2 Scheduler + 2 Tasks + 1 Test Lab + 5 Options + 2 Variable Options + 1 Cross-file Options + 1 Secrets + 1 echoPath)',
       );
       expect(
         nodejsEndpoints.keys,
-        hasLength(57),
-        reason: 'Node.js reference should also have 57 endpoints',
+        hasLength(58),
+        reason: 'Node.js reference should also have 58 endpoints',
       );
 
       // Verify both manifests have the same endpoints (normalized via

--- a/test/unit/server_test.dart
+++ b/test/unit/server_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:firebase_functions/src/common/environment.dart';
 import 'package:firebase_functions/src/firebase.dart';
 import 'package:firebase_functions/src/server.dart';
 import 'package:shelf/shelf.dart';
@@ -41,13 +42,8 @@ void main() {
       });
 
       test('rejects malformed traces', () {
-        // Too short
         expect(extractTraceId('1234/567;o=1'), isNull);
-
-        // Too long
         expect(extractTraceId('1234567890abcdef1234567890abcdef0/5'), isNull);
-
-        // Invalid hex
         expect(extractTraceId('1234567890xyzdef1234567890abcdef/5'), isNull);
       });
     });
@@ -64,119 +60,71 @@ void main() {
       });
     });
 
-    group('extractFunctionName', () {
-      // Direct emulator call: /{function}
-      test('single segment returns function name', () {
-        expect(extractFunctionName('/echo'), 'echo');
-      });
-
-      // Hosting rewrite with sub-path: /{function}/{rest}
-      // Bug: was returning the last segment ('other') instead of the first ('echo')
-      test('two segments returns first segment as function name', () {
-        expect(extractFunctionName('/echo/other'), 'echo');
-      });
-
-      // Direct emulator call with project/region: /{project}/{region}/{function}
-      test('three segments returns third segment as function name', () {
-        expect(extractFunctionName('/my-project/us-central1/echo'), 'echo');
-      });
-
-      // Hosting rewrite via full path with sub-path: /{project}/{region}/{function}/{rest}
-      // Bug: was returning the last segment ('other') instead of the third ('echo')
-      test('four segments returns third segment as function name', () {
-        expect(
-          extractFunctionName('/my-project/us-central1/echo/other'),
-          'echo',
-        );
-      });
-
-      test('root path returns empty string', () {
-        expect(extractFunctionName('/'), '');
-      });
-
-      test('empty path returns empty string', () {
-        expect(extractFunctionName(''), '');
-      });
-    });
-
-    group('routeByPath - hosting rewrites', () {
-      late String? capturedPath;
-      late List<FirebaseFunctionDeclaration> functions;
+    group('hosting rewrite path handling', () {
+      late Handler handler;
 
       setUp(() {
-        capturedPath = null;
-        functions = [
-          FirebaseFunctionDeclaration(
-            name: 'echo',
-            handler: (request) async {
-              capturedPath = request.requestedUri.path;
-              return Response.ok(capturedPath);
-            },
-            external: true,
-          ),
-        ];
+        FirebaseEnv.mockEnvironment = {'FIREBASE_PROJECT': 'demo-test'};
+        final firebase = createFirebaseInternal();
+        firebase.https.onRequest(
+          name: 'echo',
+          (request) async => Response.ok(request.requestedUri.path),
+        );
+        handler = createTestHandler(firebase);
       });
 
       // Hosting rewrite of root path: emulator sends /{function}
-      test('strips function name from root rewrite path', () async {
-        final request = Request(
-          'GET',
-          Uri.parse('http://localhost:5001/echo'),
-        );
-        await routeByPath(request, functions, request.url.path);
-        expect(capturedPath, '/');
+      test('/{fn} → handler sees /', () async {
+        final request = Request('GET', Uri.parse('http://localhost/echo'));
+        final response = await handler(request);
+        expect(await response.readAsString(), '/');
       });
 
-      // Hosting rewrite of sub-path: emulator sends /{function}/{rest}
-      test('strips function name prefix and preserves sub-path', () async {
-        final request = Request(
-          'GET',
-          Uri.parse('http://localhost:5001/echo/other'),
-        );
-        await routeByPath(request, functions, request.url.path);
-        expect(capturedPath, '/other');
+      // Hosting rewrite with sub-path: emulator sends /{function}/{rest}
+      // Bug: was routing to a function named 'other' instead of 'echo'
+      test('/{fn}/{rest} → handler sees /{rest}', () async {
+        final request = Request('GET', Uri.parse('http://localhost/echo/other'));
+        final response = await handler(request);
+        expect(await response.readAsString(), '/other');
       });
 
       // Direct emulator call: /{project}/{region}/{function}
-      test('strips project/region prefix from direct emulator call', () async {
+      test('/{project}/{region}/{fn} → handler sees /', () async {
         final request = Request(
           'GET',
-          Uri.parse('http://localhost:5001/my-project/us-central1/echo'),
+          Uri.parse('http://localhost/my-project/us-central1/echo'),
         );
-        await routeByPath(request, functions, request.url.path);
-        expect(capturedPath, '/');
+        final response = await handler(request);
+        expect(await response.readAsString(), '/');
       });
 
       // Direct emulator call with sub-path: /{project}/{region}/{function}/{rest}
-      test('strips project/region prefix and preserves sub-path', () async {
+      test('/{project}/{region}/{fn}/{rest} → handler sees /{rest}', () async {
         final request = Request(
           'GET',
-          Uri.parse(
-            'http://localhost:5001/my-project/us-central1/echo/other',
-          ),
+          Uri.parse('http://localhost/my-project/us-central1/echo/other'),
         );
-        await routeByPath(request, functions, request.url.path);
-        expect(capturedPath, '/other');
+        final response = await handler(request);
+        expect(await response.readAsString(), '/other');
       });
 
-      // Hosting rewrite with X-Firebase-Function header (set by firebase-tools)
-      test('uses X-Firebase-Function header to route and strips prefix',
-          () async {
+      // X-Firebase-Function header: emulator uses /{fn}/{rest} even for deep paths
+      test('X-Firebase-Function header routes correctly for deep path', () async {
         final request = Request(
           'GET',
-          Uri.parse('http://localhost:5001/echo/deep/path'),
+          Uri.parse('http://localhost/echo/deep/path'),
           headers: {'x-firebase-function': 'echo'},
         );
-        await routeByPath(request, functions, request.url.path);
-        expect(capturedPath, '/deep/path');
+        final response = await handler(request);
+        expect(await response.readAsString(), '/deep/path');
       });
 
-      test('returns 404 for unknown function', () async {
+      test('unknown function returns 404', () async {
         final request = Request(
           'GET',
-          Uri.parse('http://localhost:5001/unknown'),
+          Uri.parse('http://localhost/unknown'),
         );
-        final response = await routeByPath(request, functions, request.url.path);
+        final response = await handler(request);
         expect(response.statusCode, 404);
       });
     });

--- a/test/unit/server_test.dart
+++ b/test/unit/server_test.dart
@@ -111,6 +111,17 @@ void main() {
         expect(await response.readAsString(), '/other');
       });
 
+      // Emulator sends /{fn}/{a}/{b} for a client request to /{a}/{b} — 3 segments,
+      // no header. Must not be confused with /{project}/{region}/{fn} direct format.
+      test('/{fn}/{a}/{b} → handler sees /{a}/{b} (no header)', () async {
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost/echo/deep/path'),
+        );
+        final response = await handler(request);
+        expect(await response.readAsString(), '/deep/path');
+      });
+
       // X-Firebase-Function header: emulator uses /{fn}/{rest} even for deep paths
       test(
         'X-Firebase-Function header routes correctly for deep path',

--- a/test/unit/server_test.dart
+++ b/test/unit/server_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:firebase_functions/src/firebase.dart';
 import 'package:firebase_functions/src/server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
@@ -60,6 +61,123 @@ void main() {
       test('accepts a custom header value', () {
         const opts = RunFunctionsOptions(poweredByHeader: 'MyApp/1.0');
         expect(opts.poweredByHeader, 'MyApp/1.0');
+      });
+    });
+
+    group('extractFunctionName', () {
+      // Direct emulator call: /{function}
+      test('single segment returns function name', () {
+        expect(extractFunctionName('/echo'), 'echo');
+      });
+
+      // Hosting rewrite with sub-path: /{function}/{rest}
+      // Bug: was returning the last segment ('other') instead of the first ('echo')
+      test('two segments returns first segment as function name', () {
+        expect(extractFunctionName('/echo/other'), 'echo');
+      });
+
+      // Direct emulator call with project/region: /{project}/{region}/{function}
+      test('three segments returns third segment as function name', () {
+        expect(extractFunctionName('/my-project/us-central1/echo'), 'echo');
+      });
+
+      // Hosting rewrite via full path with sub-path: /{project}/{region}/{function}/{rest}
+      // Bug: was returning the last segment ('other') instead of the third ('echo')
+      test('four segments returns third segment as function name', () {
+        expect(
+          extractFunctionName('/my-project/us-central1/echo/other'),
+          'echo',
+        );
+      });
+
+      test('root path returns empty string', () {
+        expect(extractFunctionName('/'), '');
+      });
+
+      test('empty path returns empty string', () {
+        expect(extractFunctionName(''), '');
+      });
+    });
+
+    group('routeByPath - hosting rewrites', () {
+      late String? capturedPath;
+      late List<FirebaseFunctionDeclaration> functions;
+
+      setUp(() {
+        capturedPath = null;
+        functions = [
+          FirebaseFunctionDeclaration(
+            name: 'echo',
+            handler: (request) async {
+              capturedPath = request.requestedUri.path;
+              return Response.ok(capturedPath);
+            },
+            external: true,
+          ),
+        ];
+      });
+
+      // Hosting rewrite of root path: emulator sends /{function}
+      test('strips function name from root rewrite path', () async {
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost:5001/echo'),
+        );
+        await routeByPath(request, functions, request.url.path);
+        expect(capturedPath, '/');
+      });
+
+      // Hosting rewrite of sub-path: emulator sends /{function}/{rest}
+      test('strips function name prefix and preserves sub-path', () async {
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost:5001/echo/other'),
+        );
+        await routeByPath(request, functions, request.url.path);
+        expect(capturedPath, '/other');
+      });
+
+      // Direct emulator call: /{project}/{region}/{function}
+      test('strips project/region prefix from direct emulator call', () async {
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost:5001/my-project/us-central1/echo'),
+        );
+        await routeByPath(request, functions, request.url.path);
+        expect(capturedPath, '/');
+      });
+
+      // Direct emulator call with sub-path: /{project}/{region}/{function}/{rest}
+      test('strips project/region prefix and preserves sub-path', () async {
+        final request = Request(
+          'GET',
+          Uri.parse(
+            'http://localhost:5001/my-project/us-central1/echo/other',
+          ),
+        );
+        await routeByPath(request, functions, request.url.path);
+        expect(capturedPath, '/other');
+      });
+
+      // Hosting rewrite with X-Firebase-Function header (set by firebase-tools)
+      test('uses X-Firebase-Function header to route and strips prefix',
+          () async {
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost:5001/echo/deep/path'),
+          headers: {'x-firebase-function': 'echo'},
+        );
+        await routeByPath(request, functions, request.url.path);
+        expect(capturedPath, '/deep/path');
+      });
+
+      test('returns 404 for unknown function', () async {
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost:5001/unknown'),
+        );
+        final response = await routeByPath(request, functions, request.url.path);
+        expect(response.statusCode, 404);
       });
     });
 

--- a/test/unit/server_test.dart
+++ b/test/unit/server_test.dart
@@ -83,7 +83,10 @@ void main() {
       // Hosting rewrite with sub-path: emulator sends /{function}/{rest}
       // Bug: was routing to a function named 'other' instead of 'echo'
       test('/{fn}/{rest} → handler sees /{rest}', () async {
-        final request = Request('GET', Uri.parse('http://localhost/echo/other'));
+        final request = Request(
+          'GET',
+          Uri.parse('http://localhost/echo/other'),
+        );
         final response = await handler(request);
         expect(await response.readAsString(), '/other');
       });
@@ -109,21 +112,21 @@ void main() {
       });
 
       // X-Firebase-Function header: emulator uses /{fn}/{rest} even for deep paths
-      test('X-Firebase-Function header routes correctly for deep path', () async {
-        final request = Request(
-          'GET',
-          Uri.parse('http://localhost/echo/deep/path'),
-          headers: {'x-firebase-function': 'echo'},
-        );
-        final response = await handler(request);
-        expect(await response.readAsString(), '/deep/path');
-      });
+      test(
+        'X-Firebase-Function header routes correctly for deep path',
+        () async {
+          final request = Request(
+            'GET',
+            Uri.parse('http://localhost/echo/deep/path'),
+            headers: {'x-firebase-function': 'echo'},
+          );
+          final response = await handler(request);
+          expect(await response.readAsString(), '/deep/path');
+        },
+      );
 
       test('unknown function returns 404', () async {
-        final request = Request(
-          'GET',
-          Uri.parse('http://localhost/unknown'),
-        );
+        final request = Request('GET', Uri.parse('http://localhost/unknown'));
         final response = await handler(request);
         expect(response.statusCode, 404);
       });


### PR DESCRIPTION
Fixes #175

Fixes request path handling for Firebase Hosting rewrites in the emulator: the old heuristic guessed the function name from segment count, causing handlers to receive the emulator's routing prefix instead of the original client path. 

The new routing logic matches registered function names directly against path segments and reconstructs the request with the correct path before dispatching. 

Adds unit tests, E2E tests via a new echoPath fixture, and a minimal hosting example.

Dependent on https://github.com/firebase/firebase-tools/pull/10588