### PR TITLE
refactor(logger): delegate event handler error logging to shelf middleware

### DIFF
--- a/lib/src/alerts/alerts_namespace.dart
+++ b/lib/src/alerts/alerts_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'alert_event.dart';
 import 'alert_type.dart';
@@ -102,8 +101,6 @@ class AlertsNamespace extends FunctionsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/alerts/alerts_namespace.dart
+++ b/lib/src/alerts/alerts_namespace.dart
@@ -86,6 +86,7 @@ class AlertsNamespace extends FunctionsNamespace {
     final functionName = _alertTypeToFunctionName(alertType.value);
 
     firebase.registerFunction(functionName, (request) async {
+      final AlertEvent<T> event;
       try {
         final json = await parseAndValidateCloudEvent(request);
 
@@ -96,12 +97,13 @@ class AlertsNamespace extends FunctionsNamespace {
           );
         }
 
-        final event = AlertEvent<T>.fromJson(json, fromJson);
-        await handler(event);
-        return Response.ok('');
+        event = AlertEvent<T>.fromJson(json, fromJson);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     });
   }
 

--- a/lib/src/alerts/app_distribution_namespace.dart
+++ b/lib/src/alerts/app_distribution_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'alert_event.dart';
 import 'alert_type.dart';
@@ -84,8 +83,6 @@ class AppDistributionNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/alerts/app_distribution_namespace.dart
+++ b/lib/src/alerts/app_distribution_namespace.dart
@@ -68,6 +68,7 @@ class AppDistributionNamespace {
     final functionName = _alertTypeToFunctionName(alertType.value);
 
     _firebase.registerFunction(functionName, (request) async {
+      final AlertEvent<T> event;
       try {
         final json = await parseAndValidateCloudEvent(request);
 
@@ -78,12 +79,13 @@ class AppDistributionNamespace {
           );
         }
 
-        final event = AlertEvent<T>.fromJson(json, payloadDecoder);
-        await handler(event);
-        return Response.ok('');
+        event = AlertEvent<T>.fromJson(json, payloadDecoder);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     });
   }
 

--- a/lib/src/alerts/billing_namespace.dart
+++ b/lib/src/alerts/billing_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'alert_event.dart';
 import 'alert_type.dart';
@@ -85,8 +84,6 @@ class BillingNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/alerts/billing_namespace.dart
+++ b/lib/src/alerts/billing_namespace.dart
@@ -69,6 +69,7 @@ class BillingNamespace {
     final functionName = _alertTypeToFunctionName(alertType.value);
 
     _firebase.registerFunction(functionName, (request) async {
+      final AlertEvent<T> event;
       try {
         final json = await parseAndValidateCloudEvent(request);
 
@@ -79,12 +80,13 @@ class BillingNamespace {
           );
         }
 
-        final event = AlertEvent<T>.fromJson(json, payloadDecoder);
-        await handler(event);
-        return Response.ok('');
+        event = AlertEvent<T>.fromJson(json, payloadDecoder);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     });
   }
 

--- a/lib/src/alerts/crashlytics_namespace.dart
+++ b/lib/src/alerts/crashlytics_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'alert_event.dart';
 import 'alert_type.dart';
@@ -141,8 +140,6 @@ class CrashlyticsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/alerts/crashlytics_namespace.dart
+++ b/lib/src/alerts/crashlytics_namespace.dart
@@ -125,6 +125,7 @@ class CrashlyticsNamespace {
     final functionName = _alertTypeToFunctionName(alertType.value);
 
     _firebase.registerFunction(functionName, (request) async {
+      final AlertEvent<T> event;
       try {
         final json = await parseAndValidateCloudEvent(request);
 
@@ -135,12 +136,13 @@ class CrashlyticsNamespace {
           );
         }
 
-        final event = AlertEvent<T>.fromJson(json, payloadDecoder);
-        await handler(event);
-        return Response.ok('');
+        event = AlertEvent<T>.fromJson(json, payloadDecoder);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     });
   }
 

--- a/lib/src/alerts/performance_namespace.dart
+++ b/lib/src/alerts/performance_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'alert_event.dart';
 import 'alert_type.dart';
@@ -70,8 +69,6 @@ class PerformanceNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/alerts/performance_namespace.dart
+++ b/lib/src/alerts/performance_namespace.dart
@@ -54,6 +54,7 @@ class PerformanceNamespace {
     final functionName = _alertTypeToFunctionName(alertType.value);
 
     _firebase.registerFunction(functionName, (request) async {
+      final AlertEvent<T> event;
       try {
         final json = await parseAndValidateCloudEvent(request);
 
@@ -64,12 +65,13 @@ class PerformanceNamespace {
           );
         }
 
-        final event = AlertEvent<T>.fromJson(json, payloadDecoder);
-        await handler(event);
-        return Response.ok('');
+        event = AlertEvent<T>.fromJson(json, payloadDecoder);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     });
   }
 

--- a/lib/src/common/utilities.dart
+++ b/lib/src/common/utilities.dart
@@ -15,9 +15,7 @@
 import 'dart:convert';
 
 import 'package:shelf/shelf.dart' show Request, Response;
-import 'package:stack_trace/stack_trace.dart' show Trace;
 
-import '../../logger.dart' as logger;
 import '../https/error.dart';
 
 Future<Map<String, dynamic>> readAsJsonMap(Request request) async {
@@ -36,31 +34,4 @@ extension HttpErrorExtension on HttpsError {
     headers: {'Content-Type': 'application/json'},
     body: jsonEncode(toErrorResponse()),
   );
-}
-
-/// Logs an unexpected error with its stack trace and returns an [InternalError].
-///
-/// Use in HTTPS and callable function handlers where the response must be
-/// a structured JSON error. The actual error details are only logged
-/// server-side and never exposed to the client.
-InternalError logInternalError(Object error, StackTrace stackTrace) {
-  _logError(error, stackTrace);
-  return InternalError();
-}
-
-/// Logs an unexpected error with its stack trace and returns a generic 500
-/// response.
-///
-/// Use in event-triggered function handlers (Firestore, PubSub, Storage, etc.)
-/// where the caller is the Cloud Functions infrastructure rather than an
-/// end-user client.
-Response logEventHandlerError(Object error, StackTrace stackTrace) {
-  _logError(error, stackTrace);
-  return Response.internalServerError();
-}
-
-/// Formats and logs an error with a terse, readable stack trace.
-void _logError(Object error, StackTrace stackTrace) {
-  final terse = Trace.from(stackTrace).terse;
-  logger.error('$error\n$terse');
 }

--- a/lib/src/database/database_namespace.dart
+++ b/lib/src/database/database_namespace.dart
@@ -19,7 +19,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'data_snapshot.dart';
 import 'event.dart';
@@ -123,26 +122,22 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - snapshot remains null
           }
 
-          try {
-            final event = DatabaseEvent<DataSnapshot?>(
-              data: snapshot,
-              id: ceId,
-              source: ceSource,
-              specversion: '1.0',
-              subject: ceSubject,
-              time: DateTime.parse(ceTime),
-              type: ceType ?? createdEventType,
-              firebaseDatabaseHost: databaseHost,
-              instance: instanceName,
-              ref: refPath,
-              location: location,
-              params: params,
-            );
+          final event = DatabaseEvent<DataSnapshot?>(
+            data: snapshot,
+            id: ceId,
+            source: ceSource,
+            specversion: '1.0',
+            subject: ceSubject,
+            time: DateTime.parse(ceTime),
+            type: ceType ?? createdEventType,
+            firebaseDatabaseHost: databaseHost,
+            instance: instanceName,
+            ref: refPath,
+            location: location,
+            params: params,
+          );
 
-            await handler(event);
-          } catch (e, stackTrace) {
-            return logEventHandlerError(e, stackTrace);
-          }
+          await handler(event);
 
           return Response.ok('');
         } else {
@@ -191,8 +186,6 @@ class DatabaseNamespace extends FunctionsNamespace {
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     }, refPattern: _normalizeRefPattern(ref));
   }
@@ -288,26 +281,22 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - change remains null
           }
 
-          try {
-            final event = DatabaseEvent<Change<DataSnapshot>?>(
-              data: change,
-              id: ceId,
-              source: ceSource,
-              specversion: '1.0',
-              subject: ceSubject,
-              time: DateTime.parse(ceTime),
-              type: ceType ?? updatedEventType,
-              firebaseDatabaseHost: databaseHost,
-              instance: instanceName,
-              ref: refPath,
-              location: location,
-              params: params,
-            );
+          final event = DatabaseEvent<Change<DataSnapshot>?>(
+            data: change,
+            id: ceId,
+            source: ceSource,
+            specversion: '1.0',
+            subject: ceSubject,
+            time: DateTime.parse(ceTime),
+            type: ceType ?? updatedEventType,
+            firebaseDatabaseHost: databaseHost,
+            instance: instanceName,
+            ref: refPath,
+            location: location,
+            params: params,
+          );
 
-            await handler(event);
-          } catch (e, stackTrace) {
-            return logEventHandlerError(e, stackTrace);
-          }
+          await handler(event);
 
           return Response.ok('');
         } else {
@@ -449,26 +438,22 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - snapshot remains null
           }
 
-          try {
-            final event = DatabaseEvent<DataSnapshot?>(
-              data: snapshot,
-              id: ceId,
-              source: ceSource,
-              specversion: '1.0',
-              subject: ceSubject,
-              time: DateTime.parse(ceTime),
-              type: ceType ?? deletedEventType,
-              firebaseDatabaseHost: databaseHost,
-              instance: instanceName,
-              ref: refPath,
-              location: location,
-              params: params,
-            );
+          final event = DatabaseEvent<DataSnapshot?>(
+            data: snapshot,
+            id: ceId,
+            source: ceSource,
+            specversion: '1.0',
+            subject: ceSubject,
+            time: DateTime.parse(ceTime),
+            type: ceType ?? deletedEventType,
+            firebaseDatabaseHost: databaseHost,
+            instance: instanceName,
+            ref: refPath,
+            location: location,
+            params: params,
+          );
 
-            await handler(event);
-          } catch (e, stackTrace) {
-            return logEventHandlerError(e, stackTrace);
-          }
+          await handler(event);
 
           return Response.ok('');
         } else {
@@ -624,26 +609,22 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - change remains null
           }
 
-          try {
-            final event = DatabaseEvent<Change<DataSnapshot>?>(
-              data: change,
-              id: ceId,
-              source: ceSource,
-              specversion: '1.0',
-              subject: ceSubject,
-              time: DateTime.parse(ceTime),
-              type: ceType ?? writtenEventType,
-              firebaseDatabaseHost: databaseHost,
-              instance: instanceName,
-              ref: refPath,
-              location: location,
-              params: params,
-            );
+          final event = DatabaseEvent<Change<DataSnapshot>?>(
+            data: change,
+            id: ceId,
+            source: ceSource,
+            specversion: '1.0',
+            subject: ceSubject,
+            time: DateTime.parse(ceTime),
+            type: ceType ?? writtenEventType,
+            firebaseDatabaseHost: databaseHost,
+            instance: instanceName,
+            ref: refPath,
+            location: location,
+            params: params,
+          );
 
-            await handler(event);
-          } catch (e, stackTrace) {
-            return logEventHandlerError(e, stackTrace);
-          }
+          await handler(event);
 
           return Response.ok('');
         } else {

--- a/lib/src/database/database_namespace.dart
+++ b/lib/src/database/database_namespace.dart
@@ -79,6 +79,7 @@ class DatabaseNamespace extends FunctionsNamespace {
     final instance = options?.instance ?? '*';
 
     firebase.registerFunction(functionName, (request) async {
+      final DatabaseEvent<DataSnapshot?> event;
       try {
         final isBinaryMode = request.headers.containsKey('ce-type');
 
@@ -122,7 +123,7 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - snapshot remains null
           }
 
-          final event = DatabaseEvent<DataSnapshot?>(
+          event = DatabaseEvent<DataSnapshot?>(
             data: snapshot,
             id: ceId,
             source: ceSource,
@@ -136,10 +137,6 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: location,
             params: params,
           );
-
-          await handler(event);
-
-          return Response.ok('');
         } else {
           // Structured content mode: full CloudEvent in JSON body
           final json = await parseAndValidateCloudEvent(request);
@@ -166,7 +163,7 @@ class DatabaseNamespace extends FunctionsNamespace {
 
           final params = _extractParams(ref, refPath);
 
-          final event = DatabaseEvent<DataSnapshot?>(
+          event = DatabaseEvent<DataSnapshot?>(
             data: snapshot,
             id: json['id'] as String,
             source: json['source'] as String,
@@ -180,13 +177,13 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: json['location'] as String? ?? 'us-central1',
             params: params,
           );
-
-          await handler(event);
-          return Response.ok('');
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     }, refPattern: _normalizeRefPattern(ref));
   }
 
@@ -225,6 +222,7 @@ class DatabaseNamespace extends FunctionsNamespace {
     final instance = options?.instance ?? '*';
 
     firebase.registerFunction(functionName, (request) async {
+      final DatabaseEvent<Change<DataSnapshot>?> event;
       try {
         final isBinaryMode = request.headers.containsKey('ce-type');
 
@@ -281,7 +279,7 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - change remains null
           }
 
-          final event = DatabaseEvent<Change<DataSnapshot>?>(
+          event = DatabaseEvent<Change<DataSnapshot>?>(
             data: change,
             id: ceId,
             source: ceSource,
@@ -295,10 +293,6 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: location,
             params: params,
           );
-
-          await handler(event);
-
-          return Response.ok('');
         } else {
           // Structured content mode: full CloudEvent in JSON body
           final json = await parseAndValidateCloudEvent(request);
@@ -336,7 +330,7 @@ class DatabaseNamespace extends FunctionsNamespace {
 
           final params = _extractParams(ref, refPath);
 
-          final event = DatabaseEvent<Change<DataSnapshot>?>(
+          event = DatabaseEvent<Change<DataSnapshot>?>(
             data: change,
             id: json['id'] as String,
             source: json['source'] as String,
@@ -350,13 +344,13 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: json['location'] as String? ?? 'us-central1',
             params: params,
           );
-
-          await handler(event);
-          return Response.ok('');
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     }, refPattern: _normalizeRefPattern(ref));
   }
 
@@ -392,6 +386,7 @@ class DatabaseNamespace extends FunctionsNamespace {
     final instance = options?.instance ?? '*';
 
     firebase.registerFunction(functionName, (request) async {
+      final DatabaseEvent<DataSnapshot?> event;
       try {
         final isBinaryMode = request.headers.containsKey('ce-type');
 
@@ -435,7 +430,7 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - snapshot remains null
           }
 
-          final event = DatabaseEvent<DataSnapshot?>(
+          event = DatabaseEvent<DataSnapshot?>(
             data: snapshot,
             id: ceId,
             source: ceSource,
@@ -449,10 +444,6 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: location,
             params: params,
           );
-
-          await handler(event);
-
-          return Response.ok('');
         } else {
           // Structured content mode: full CloudEvent in JSON body
           final json = await parseAndValidateCloudEvent(request);
@@ -479,7 +470,7 @@ class DatabaseNamespace extends FunctionsNamespace {
 
           final params = _extractParams(ref, refPath);
 
-          final event = DatabaseEvent<DataSnapshot?>(
+          event = DatabaseEvent<DataSnapshot?>(
             data: snapshot,
             id: json['id'] as String,
             source: json['source'] as String,
@@ -493,13 +484,13 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: json['location'] as String? ?? 'us-central1',
             params: params,
           );
-
-          await handler(event);
-          return Response.ok('');
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     }, refPattern: _normalizeRefPattern(ref));
   }
 
@@ -546,6 +537,7 @@ class DatabaseNamespace extends FunctionsNamespace {
     final instance = options?.instance ?? '*';
 
     firebase.registerFunction(functionName, (request) async {
+      final DatabaseEvent<Change<DataSnapshot>?> event;
       try {
         final isBinaryMode = request.headers.containsKey('ce-type');
 
@@ -603,7 +595,7 @@ class DatabaseNamespace extends FunctionsNamespace {
             // Body parsing failed - change remains null
           }
 
-          final event = DatabaseEvent<Change<DataSnapshot>?>(
+          event = DatabaseEvent<Change<DataSnapshot>?>(
             data: change,
             id: ceId,
             source: ceSource,
@@ -617,10 +609,6 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: location,
             params: params,
           );
-
-          await handler(event);
-
-          return Response.ok('');
         } else {
           // Structured content mode: full CloudEvent in JSON body
           final json = await parseAndValidateCloudEvent(request);
@@ -658,7 +646,7 @@ class DatabaseNamespace extends FunctionsNamespace {
 
           final params = _extractParams(ref, refPath);
 
-          final event = DatabaseEvent<Change<DataSnapshot>?>(
+          event = DatabaseEvent<Change<DataSnapshot>?>(
             data: change,
             id: json['id'] as String,
             source: json['source'] as String,
@@ -672,13 +660,13 @@ class DatabaseNamespace extends FunctionsNamespace {
             location: json['location'] as String? ?? 'us-central1',
             params: params,
           );
-
-          await handler(event);
-          return Response.ok('');
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+      return Response.ok('');
     }, refPattern: _normalizeRefPattern(ref));
   }
 

--- a/lib/src/database/database_namespace.dart
+++ b/lib/src/database/database_namespace.dart
@@ -354,11 +354,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           await handler(event);
           return Response.ok('');
         }
-      } catch (e, stackTrace) {
-        return Response(
-          500,
-          body: 'Error processing Database event: $e\n$stackTrace',
-        );
+      } on FormatException catch (e) {
+        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
     }, refPattern: _normalizeRefPattern(ref));
   }
@@ -500,11 +497,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           await handler(event);
           return Response.ok('');
         }
-      } catch (e, stackTrace) {
-        return Response(
-          500,
-          body: 'Error processing Database event: $e\n$stackTrace',
-        );
+      } on FormatException catch (e) {
+        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
     }, refPattern: _normalizeRefPattern(ref));
   }
@@ -682,11 +676,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           await handler(event);
           return Response.ok('');
         }
-      } catch (e, stackTrace) {
-        return Response(
-          500,
-          body: 'Error processing Database event: $e\n$stackTrace',
-        );
+      } on FormatException catch (e) {
+        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
     }, refPattern: _normalizeRefPattern(ref));
   }

--- a/lib/src/eventarc/eventarc_namespace.dart
+++ b/lib/src/eventarc/eventarc_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'options.dart';
 
@@ -72,8 +71,6 @@ class EventarcNamespace extends FunctionsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/eventarc/eventarc_namespace.dart
+++ b/lib/src/eventarc/eventarc_namespace.dart
@@ -57,21 +57,22 @@ class EventarcNamespace extends FunctionsNamespace {
     final functionName = _eventTypeToFunctionName(eventType);
 
     firebase.registerFunction(functionName, (request) async {
+      final CloudEvent<Object> event;
       try {
         // Read and parse CloudEvent
         final json = await parseAndValidateCloudEvent(request);
 
         // Parse CloudEvent with generic data
-        final event = CloudEvent<Object>.fromJson(json, (data) => data);
-
-        // Execute handler
-        await handler(event);
-
-        // Return success
-        return Response.ok('');
+        event = CloudEvent<Object>.fromJson(json, (data) => data);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      // Execute handler
+      await handler(event);
+
+      // Return success
+      return Response.ok('');
     });
   }
 

--- a/lib/src/firestore/firestore_namespace.dart
+++ b/lib/src/firestore/firestore_namespace.dart
@@ -19,7 +19,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'document_snapshot.dart';
 import 'event.dart';
@@ -474,54 +473,50 @@ class FirestoreNamespace extends FunctionsNamespace {
               : 'value';
           final snapshot = parsed?[snapshotKey];
 
-          try {
-            if (withAuthContext) {
-              final event = FirestoreAuthEvent<EmulatorDocumentSnapshot?>(
-                data: snapshot,
-                id: headers.id,
-                source: headers.source,
-                specversion: '1.0',
-                subject: headers.subject,
-                time: DateTime.parse(headers.time),
-                type: headers.type,
-                location: 'us-central1',
-                project: _extractProject(headers.source),
-                database: headers.database,
-                namespace: headers.namespace,
-                document: headers.documentPath,
-                params: params,
-                authType: AuthType.fromString(headers.authType ?? 'unknown'),
-                authId: headers.authId,
-              );
+          if (withAuthContext) {
+            final event = FirestoreAuthEvent<EmulatorDocumentSnapshot?>(
+              data: snapshot,
+              id: headers.id,
+              source: headers.source,
+              specversion: '1.0',
+              subject: headers.subject,
+              time: DateTime.parse(headers.time),
+              type: headers.type,
+              location: 'us-central1',
+              project: _extractProject(headers.source),
+              database: headers.database,
+              namespace: headers.namespace,
+              document: headers.documentPath,
+              params: params,
+              authType: AuthType.fromString(headers.authType ?? 'unknown'),
+              authId: headers.authId,
+            );
 
-              await (handler
-                  as Future<void> Function(
-                    FirestoreAuthEvent<EmulatorDocumentSnapshot?>,
-                  ))(event);
-            } else {
-              final event = FirestoreEvent<EmulatorDocumentSnapshot?>(
-                data: snapshot,
-                id: headers.id,
-                source: headers.source,
-                specversion: '1.0',
-                subject: headers.subject,
-                time: DateTime.parse(headers.time),
-                type: headers.type,
-                location: 'us-central1',
-                project: _extractProject(headers.source),
-                database: headers.database,
-                namespace: headers.namespace,
-                document: headers.documentPath,
-                params: params,
-              );
+            await (handler
+                as Future<void> Function(
+                  FirestoreAuthEvent<EmulatorDocumentSnapshot?>,
+                ))(event);
+          } else {
+            final event = FirestoreEvent<EmulatorDocumentSnapshot?>(
+              data: snapshot,
+              id: headers.id,
+              source: headers.source,
+              specversion: '1.0',
+              subject: headers.subject,
+              time: DateTime.parse(headers.time),
+              type: headers.type,
+              location: 'us-central1',
+              project: _extractProject(headers.source),
+              database: headers.database,
+              namespace: headers.namespace,
+              document: headers.documentPath,
+              params: params,
+            );
 
-              await (handler
-                  as Future<void> Function(
-                    FirestoreEvent<EmulatorDocumentSnapshot?>,
-                  ))(event);
-            }
-          } catch (e, stackTrace) {
-            return logEventHandlerError(e, stackTrace);
+            await (handler
+                as Future<void> Function(
+                  FirestoreEvent<EmulatorDocumentSnapshot?>,
+                ))(event);
           }
 
           return Response.ok('');
@@ -590,8 +585,6 @@ class FirestoreNamespace extends FunctionsNamespace {
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     }, documentPattern: document);
   }
@@ -612,98 +605,86 @@ class FirestoreNamespace extends FunctionsNamespace {
     final functionName = _documentToFunctionName(methodName, document);
 
     firebase.registerFunction(functionName, (request) async {
-      try {
-        final isBinaryMode = request.headers.containsKey('ce-type');
+      final isBinaryMode = request.headers.containsKey('ce-type');
 
-        if (isBinaryMode) {
-          final ceType = request.headers['ce-type'];
+      if (isBinaryMode) {
+        final ceType = request.headers['ce-type'];
 
-          if (ceType != null && !validateEventType(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Firestore $methodName: $ceType',
-            );
-          }
-
-          final headers = _extractHeaders(request);
-          if (headers == null) {
-            return Response(400, body: 'Missing required CloudEvent headers');
-          }
-
-          final params = _extractParams(document, headers.documentPath);
-
-          final parsed = await _parseBody(request);
-          final beforeSnapshot = parsed?['old_value'];
-          final afterSnapshot = parsed?['value'];
-
-          try {
-            final change = Change<EmulatorDocumentSnapshot>(
-              before: beforeSnapshot,
-              after: afterSnapshot,
-            );
-
-            if (withAuthContext) {
-              final event =
-                  FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>(
-                    data: change,
-                    id: headers.id,
-                    source: headers.source,
-                    specversion: '1.0',
-                    subject: headers.subject,
-                    time: DateTime.parse(headers.time),
-                    type: headers.type,
-                    location: 'us-central1',
-                    project: _extractProject(headers.source),
-                    database: headers.database,
-                    namespace: headers.namespace,
-                    document: headers.documentPath,
-                    params: params,
-                    authType: AuthType.fromString(
-                      headers.authType ?? 'unknown',
-                    ),
-                    authId: headers.authId,
-                  );
-
-              await (handler
-                  as Future<void> Function(
-                    FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>,
-                  ))(event);
-            } else {
-              final event = FirestoreEvent<Change<EmulatorDocumentSnapshot>?>(
-                data: change,
-                id: headers.id,
-                source: headers.source,
-                specversion: '1.0',
-                subject: headers.subject,
-                time: DateTime.parse(headers.time),
-                type: headers.type,
-                location: 'us-central1',
-                project: _extractProject(headers.source),
-                database: headers.database,
-                namespace: headers.namespace,
-                document: headers.documentPath,
-                params: params,
-              );
-
-              await (handler
-                  as Future<void> Function(
-                    FirestoreEvent<Change<EmulatorDocumentSnapshot>?>,
-                  ))(event);
-            }
-          } catch (e, stackTrace) {
-            return logEventHandlerError(e, stackTrace);
-          }
-
-          return Response.ok('');
-        } else {
+        if (ceType != null && !validateEventType(ceType)) {
           return Response(
-            501,
-            body:
-                'Structured CloudEvent mode not yet supported for $methodName',
+            400,
+            body: 'Invalid event type for Firestore $methodName: $ceType',
           );
         }
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
+
+        final headers = _extractHeaders(request);
+        if (headers == null) {
+          return Response(400, body: 'Missing required CloudEvent headers');
+        }
+
+        final params = _extractParams(document, headers.documentPath);
+
+        final parsed = await _parseBody(request);
+        final beforeSnapshot = parsed?['old_value'];
+        final afterSnapshot = parsed?['value'];
+
+        final change = Change<EmulatorDocumentSnapshot>(
+          before: beforeSnapshot,
+          after: afterSnapshot,
+        );
+
+        if (withAuthContext) {
+          final event = FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>(
+            data: change,
+            id: headers.id,
+            source: headers.source,
+            specversion: '1.0',
+            subject: headers.subject,
+            time: DateTime.parse(headers.time),
+            type: headers.type,
+            location: 'us-central1',
+            project: _extractProject(headers.source),
+            database: headers.database,
+            namespace: headers.namespace,
+            document: headers.documentPath,
+            params: params,
+            authType: AuthType.fromString(headers.authType ?? 'unknown'),
+            authId: headers.authId,
+          );
+
+          await (handler
+              as Future<void> Function(
+                FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>,
+              ))(event);
+        } else {
+          final event = FirestoreEvent<Change<EmulatorDocumentSnapshot>?>(
+            data: change,
+            id: headers.id,
+            source: headers.source,
+            specversion: '1.0',
+            subject: headers.subject,
+            time: DateTime.parse(headers.time),
+            type: headers.type,
+            location: 'us-central1',
+            project: _extractProject(headers.source),
+            database: headers.database,
+            namespace: headers.namespace,
+            document: headers.documentPath,
+            params: params,
+          );
+
+          await (handler
+              as Future<void> Function(
+                FirestoreEvent<Change<EmulatorDocumentSnapshot>?>,
+              ))(event);
+        }
+
+        return Response.ok('');
+      } else {
+        return Response(
+          501,
+          body: 'Structured CloudEvent mode not yet supported for $methodName',
+        );
       }
     }, documentPattern: document);
   }

--- a/lib/src/firestore/firestore_namespace.dart
+++ b/lib/src/firestore/firestore_namespace.dart
@@ -445,6 +445,7 @@ class FirestoreNamespace extends FunctionsNamespace {
     final functionName = _documentToFunctionName(methodName, document);
 
     firebase.registerFunction(functionName, (request) async {
+      final Future<void> Function() executeHandler;
       try {
         final isBinaryMode = request.headers.containsKey('ce-type');
 
@@ -492,10 +493,11 @@ class FirestoreNamespace extends FunctionsNamespace {
               authId: headers.authId,
             );
 
-            await (handler
-                as Future<void> Function(
-                  FirestoreAuthEvent<EmulatorDocumentSnapshot?>,
-                ))(event);
+            executeHandler = () =>
+                (handler
+                    as Future<void> Function(
+                      FirestoreAuthEvent<EmulatorDocumentSnapshot?>,
+                    ))(event);
           } else {
             final event = FirestoreEvent<EmulatorDocumentSnapshot?>(
               data: snapshot,
@@ -513,13 +515,12 @@ class FirestoreNamespace extends FunctionsNamespace {
               params: params,
             );
 
-            await (handler
-                as Future<void> Function(
-                  FirestoreEvent<EmulatorDocumentSnapshot?>,
-                ))(event);
+            executeHandler = () =>
+                (handler
+                    as Future<void> Function(
+                      FirestoreEvent<EmulatorDocumentSnapshot?>,
+                    ))(event);
           }
-
-          return Response.ok('');
         } else {
           // Structured content mode: full CloudEvent in JSON body
           // Only supported for onDocumentCreated variants
@@ -555,10 +556,11 @@ class FirestoreNamespace extends FunctionsNamespace {
                 authId: json['authid'] as String?,
               );
 
-              await (handler
-                  as Future<void> Function(
-                    FirestoreAuthEvent<EmulatorDocumentSnapshot?>,
-                  ))(event);
+              executeHandler = () =>
+                  (handler
+                      as Future<void> Function(
+                        FirestoreAuthEvent<EmulatorDocumentSnapshot?>,
+                      ))(event);
             } else {
               final event = FirestoreEvent<EmulatorDocumentSnapshot?>.fromJson(
                 json,
@@ -568,24 +570,26 @@ class FirestoreNamespace extends FunctionsNamespace {
                 },
               );
 
-              await (handler
-                  as Future<void> Function(
-                    FirestoreEvent<EmulatorDocumentSnapshot?>,
-                  ))(event);
+              executeHandler = () =>
+                  (handler
+                      as Future<void> Function(
+                        FirestoreEvent<EmulatorDocumentSnapshot?>,
+                      ))(event);
             }
-
-            return Response.ok('');
+          } else {
+            return Response(
+              501,
+              body:
+                  'Structured CloudEvent mode not yet supported for $methodName',
+            );
           }
-
-          return Response(
-            501,
-            body:
-                'Structured CloudEvent mode not yet supported for $methodName',
-          );
         }
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await executeHandler();
+      return Response.ok('');
     }, documentPattern: document);
   }
 
@@ -605,87 +609,96 @@ class FirestoreNamespace extends FunctionsNamespace {
     final functionName = _documentToFunctionName(methodName, document);
 
     firebase.registerFunction(functionName, (request) async {
-      final isBinaryMode = request.headers.containsKey('ce-type');
+      final Future<void> Function() executeHandler;
+      try {
+        final isBinaryMode = request.headers.containsKey('ce-type');
 
-      if (isBinaryMode) {
-        final ceType = request.headers['ce-type'];
+        if (isBinaryMode) {
+          final ceType = request.headers['ce-type'];
 
-        if (ceType != null && !validateEventType(ceType)) {
-          return Response(
-            400,
-            body: 'Invalid event type for Firestore $methodName: $ceType',
-          );
-        }
+          if (ceType != null && !validateEventType(ceType)) {
+            return Response(
+              400,
+              body: 'Invalid event type for Firestore $methodName: $ceType',
+            );
+          }
 
-        final headers = _extractHeaders(request);
-        if (headers == null) {
-          return Response(400, body: 'Missing required CloudEvent headers');
-        }
+          final headers = _extractHeaders(request);
+          if (headers == null) {
+            return Response(400, body: 'Missing required CloudEvent headers');
+          }
 
-        final params = _extractParams(document, headers.documentPath);
+          final params = _extractParams(document, headers.documentPath);
 
-        final parsed = await _parseBody(request);
-        final beforeSnapshot = parsed?['old_value'];
-        final afterSnapshot = parsed?['value'];
+          final parsed = await _parseBody(request);
+          final beforeSnapshot = parsed?['old_value'];
+          final afterSnapshot = parsed?['value'];
 
-        final change = Change<EmulatorDocumentSnapshot>(
-          before: beforeSnapshot,
-          after: afterSnapshot,
-        );
-
-        if (withAuthContext) {
-          final event = FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>(
-            data: change,
-            id: headers.id,
-            source: headers.source,
-            specversion: '1.0',
-            subject: headers.subject,
-            time: DateTime.parse(headers.time),
-            type: headers.type,
-            location: 'us-central1',
-            project: _extractProject(headers.source),
-            database: headers.database,
-            namespace: headers.namespace,
-            document: headers.documentPath,
-            params: params,
-            authType: AuthType.fromString(headers.authType ?? 'unknown'),
-            authId: headers.authId,
+          final change = Change<EmulatorDocumentSnapshot>(
+            before: beforeSnapshot,
+            after: afterSnapshot,
           );
 
-          await (handler
-              as Future<void> Function(
-                FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>,
-              ))(event);
+          if (withAuthContext) {
+            final event = FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>(
+              data: change,
+              id: headers.id,
+              source: headers.source,
+              specversion: '1.0',
+              subject: headers.subject,
+              time: DateTime.parse(headers.time),
+              type: headers.type,
+              location: 'us-central1',
+              project: _extractProject(headers.source),
+              database: headers.database,
+              namespace: headers.namespace,
+              document: headers.documentPath,
+              params: params,
+              authType: AuthType.fromString(headers.authType ?? 'unknown'),
+              authId: headers.authId,
+            );
+
+            executeHandler = () =>
+                (handler
+                    as Future<void> Function(
+                      FirestoreAuthEvent<Change<EmulatorDocumentSnapshot>?>,
+                    ))(event);
+          } else {
+            final event = FirestoreEvent<Change<EmulatorDocumentSnapshot>?>(
+              data: change,
+              id: headers.id,
+              source: headers.source,
+              specversion: '1.0',
+              subject: headers.subject,
+              time: DateTime.parse(headers.time),
+              type: headers.type,
+              location: 'us-central1',
+              project: _extractProject(headers.source),
+              database: headers.database,
+              namespace: headers.namespace,
+              document: headers.documentPath,
+              params: params,
+            );
+
+            executeHandler = () =>
+                (handler
+                    as Future<void> Function(
+                      FirestoreEvent<Change<EmulatorDocumentSnapshot>?>,
+                    ))(event);
+          }
         } else {
-          final event = FirestoreEvent<Change<EmulatorDocumentSnapshot>?>(
-            data: change,
-            id: headers.id,
-            source: headers.source,
-            specversion: '1.0',
-            subject: headers.subject,
-            time: DateTime.parse(headers.time),
-            type: headers.type,
-            location: 'us-central1',
-            project: _extractProject(headers.source),
-            database: headers.database,
-            namespace: headers.namespace,
-            document: headers.documentPath,
-            params: params,
+          return Response(
+            501,
+            body:
+                'Structured CloudEvent mode not yet supported for $methodName',
           );
-
-          await (handler
-              as Future<void> Function(
-                FirestoreEvent<Change<EmulatorDocumentSnapshot>?>,
-              ))(event);
         }
-
-        return Response.ok('');
-      } else {
-        return Response(
-          501,
-          body: 'Structured CloudEvent mode not yet supported for $methodName',
-        );
+      } on FormatException catch (e) {
+        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await executeHandler();
+      return Response.ok('');
     }, documentPattern: document);
   }
 

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -59,8 +59,6 @@ class HttpsNamespace extends FunctionsNamespace {
           return await handler(request);
         } on HttpsError catch (e) {
           return e.toShelfResponse();
-        } catch (e, stackTrace) {
-          return logInternalError(e, stackTrace).toShelfResponse();
         }
       },
       external: true,
@@ -302,9 +300,9 @@ class HttpsNamespace extends FunctionsNamespace {
       }
 
       return e.toShelfResponse();
-    } catch (e, stackTrace) {
+    } catch (e) {
       // Unexpected error - don't expose details to client
-      final error = logInternalError(e, stackTrace);
+      final error = InternalError();
 
       if (callableRequest.acceptsStreaming && !callableResponse.aborted) {
         callableResponse.writeSSE(error.toErrorResponse());

--- a/lib/src/identity/identity_namespace.dart
+++ b/lib/src/identity/identity_namespace.dart
@@ -249,8 +249,6 @@ class IdentityNamespace extends FunctionsNamespace {
         );
       } on HttpsError catch (e) {
         return e.toShelfResponse();
-      } catch (e, stackTrace) {
-        return logInternalError(e, stackTrace).toShelfResponse();
       }
     });
   }

--- a/lib/src/pubsub/pubsub_namespace.dart
+++ b/lib/src/pubsub/pubsub_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'message.dart';
 import 'options.dart';
@@ -80,8 +79,6 @@ class PubSubNamespace extends FunctionsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/pubsub/pubsub_namespace.dart
+++ b/lib/src/pubsub/pubsub_namespace.dart
@@ -54,6 +54,7 @@ class PubSubNamespace extends FunctionsNamespace {
     final functionName = _topicToFunctionName(topic);
 
     firebase.registerFunction(functionName, (request) async {
+      final CloudEvent<PubsubMessage> event;
       try {
         // Read and parse CloudEvent
         final json = await parseAndValidateCloudEvent(request);
@@ -67,19 +68,19 @@ class PubSubNamespace extends FunctionsNamespace {
         }
 
         // Parse CloudEvent with PubsubMessage data
-        final event = CloudEvent<PubsubMessage>.fromJson(
+        event = CloudEvent<PubsubMessage>.fromJson(
           json,
           PubsubMessage.fromJson,
         );
-
-        // Execute handler
-        await handler(event);
-
-        // Return success
-        return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      // Execute handler
+      await handler(event);
+
+      // Return success
+      return Response.ok('');
     });
   }
 

--- a/lib/src/remote_config/remote_config_namespace.dart
+++ b/lib/src/remote_config/remote_config_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'config_update_data.dart';
 import 'options.dart';
@@ -76,8 +75,6 @@ class RemoteConfigNamespace extends FunctionsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/remote_config/remote_config_namespace.dart
+++ b/lib/src/remote_config/remote_config_namespace.dart
@@ -50,6 +50,7 @@ class RemoteConfigNamespace extends FunctionsNamespace {
     const functionName = 'onConfigUpdated';
 
     firebase.registerFunction(functionName, (request) async {
+      final CloudEvent<ConfigUpdateData> event;
       try {
         // Read and parse CloudEvent
         final json = await parseAndValidateCloudEvent(request);
@@ -63,19 +64,19 @@ class RemoteConfigNamespace extends FunctionsNamespace {
         }
 
         // Parse CloudEvent with ConfigUpdateData
-        final event = CloudEvent<ConfigUpdateData>.fromJson(
+        event = CloudEvent<ConfigUpdateData>.fromJson(
           json,
           ConfigUpdateData.fromJson,
         );
-
-        // Execute handler
-        await handler(event);
-
-        // Return success
-        return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      // Execute handler
+      await handler(event);
+
+      // Return success
+      return Response.ok('');
     });
   }
 

--- a/lib/src/scheduler/scheduler_namespace.dart
+++ b/lib/src/scheduler/scheduler_namespace.dart
@@ -17,7 +17,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'options.dart';
 import 'scheduled_event.dart';
@@ -95,20 +94,15 @@ class SchedulerNamespace extends FunctionsNamespace {
     final functionName = _scheduleToFunctionName(schedule);
 
     firebase.registerFunction(functionName, (request) async {
-      try {
-        // Extract event data from request headers
-        final headers = _lowercaseHeaders(request.headers);
-        final event = ScheduledEvent.fromHeaders(headers);
+      // Extract event data from request headers
+      final headers = _lowercaseHeaders(request.headers);
+      final event = ScheduledEvent.fromHeaders(headers);
 
-        // Execute handler
-        await handler(event);
+      // Execute handler
+      await handler(event);
 
-        // Return success (Cloud Scheduler expects 2xx response)
-        return Response.ok('');
-      } catch (e, stackTrace) {
-        // Cloud Scheduler will retry based on retry config
-        return logEventHandlerError(e, stackTrace);
-      }
+      // Return success (Cloud Scheduler expects 2xx response)
+      return Response.ok('');
     });
   }
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -116,8 +116,22 @@ Future<void> runFunctions(
 ///
 /// Use in tests to exercise the full routing pipeline without binding a port.
 @visibleForTesting
-Handler createTestHandler(Firebase firebase) =>
-    (request) => _routeRequest(request, firebase, firebase.$env);
+Handler createTestHandler(Firebase firebase) {
+  final env = firebase.$env;
+  var middleware = const Pipeline().middleware;
+
+  if (env.enableCors) {
+    middleware = middleware.addMiddleware(_corsMiddleware);
+  }
+
+  middleware = middleware.addMiddleware(
+    createLoggingMiddleware(projectId: env.projectId),
+  );
+
+  return middleware.addHandler(
+    (request) => _routeRequest(request, firebase, env),
+  );
+}
 
 /// CORS middleware for emulator mode.
 Handler _corsMiddleware(Handler innerHandler) => (request) {

--- a/lib/src/storage/storage_namespace.dart
+++ b/lib/src/storage/storage_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'options.dart';
 import 'storage_event.dart';
@@ -163,8 +162,6 @@ class StorageNamespace extends FunctionsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/storage/storage_namespace.dart
+++ b/lib/src/storage/storage_namespace.dart
@@ -139,6 +139,7 @@ class StorageNamespace extends FunctionsNamespace {
     final functionName = _bucketToFunctionName(methodName, bucket);
 
     firebase.registerFunction(functionName, (request) async {
+      final StorageEvent event;
       try {
         // Read and parse CloudEvent
         final json = await parseAndValidateCloudEvent(request);
@@ -153,16 +154,16 @@ class StorageNamespace extends FunctionsNamespace {
         }
 
         // Parse CloudEvent with StorageObjectData
-        final event = StorageEvent.fromJson(json);
-
-        // Execute handler
-        await handler(event);
-
-        // Return success
-        return Response.ok('');
+        event = StorageEvent.fromJson(json);
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      // Execute handler
+      await handler(event);
+
+      // Return success
+      return Response.ok('');
     });
   }
 

--- a/lib/src/test_lab/test_lab_namespace.dart
+++ b/lib/src/test_lab/test_lab_namespace.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/cloud_event.dart';
-import '../common/utilities.dart';
 import '../firebase.dart';
 import 'options.dart';
 import 'test_matrix_completed_data.dart';
@@ -71,8 +70,6 @@ class TestLabNamespace extends FunctionsNamespace {
         return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
-      } catch (e, stackTrace) {
-        return logEventHandlerError(e, stackTrace);
       }
     });
   }

--- a/lib/src/test_lab/test_lab_namespace.dart
+++ b/lib/src/test_lab/test_lab_namespace.dart
@@ -49,6 +49,7 @@ class TestLabNamespace extends FunctionsNamespace {
     @mustBeConst TestLabOptions? options = const TestLabOptions(),
   }) {
     firebase.registerFunction(_functionName, (request) async {
+      final CloudEvent<TestMatrixCompletedData> event;
       try {
         final json = await parseAndValidateCloudEvent(request);
 
@@ -60,17 +61,17 @@ class TestLabNamespace extends FunctionsNamespace {
           );
         }
 
-        final event = CloudEvent<TestMatrixCompletedData>.fromJson(
+        event = CloudEvent<TestMatrixCompletedData>.fromJson(
           json,
           TestMatrixCompletedData.fromJson,
         );
-
-        await handler(event);
-
-        return Response.ok('');
       } on FormatException catch (e) {
         return Response(400, body: 'Invalid CloudEvent: ${e.message}');
       }
+
+      await handler(event);
+
+      return Response.ok('');
     });
   }
 

--- a/test/e2e/helpers/http_client.dart
+++ b/test/e2e/helpers/http_client.dart
@@ -22,10 +22,16 @@ final class FunctionsHttpClient extends TestClientBase {
   FunctionsHttpClient(super.baseUrl);
 
   /// Calls an onRequest function with GET method.
-  Future<http.Response> get(String functionName) async {
+  Future<http.Response> get(
+    String functionName, {
+    Map<String, String>? headers,
+  }) async {
     final url = Uri.parse('$baseUrl/$functionName');
     print('GET $url');
-    return await client.get(url);
+    return await client.get(
+      url,
+      headers: {'Accept': 'application/json', ...?headers},
+    );
   }
 
   /// Calls an onRequest function with POST method.

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -79,22 +79,26 @@ void runHttpsOnRequestTests(
       expect(response.statusCode, equals(404));
     });
 
-    test('handles multiple concurrent requests', () async {
-      // Reduced from 10 to 5 requests to avoid CI timeout issues
-      // The emulator spawns separate workers which can be slow in CI
-      print('Making 5 concurrent requests...');
-      final futures = <Future<void>>[];
+    test(
+      'handles multiple concurrent requests',
+      () async {
+        // Reduced from 10 to 5 requests to avoid CI timeout issues
+        // The emulator spawns separate workers which can be slow in CI
+        print('Making 5 concurrent requests...');
+        final futures = <Future<void>>[];
 
-      for (var i = 0; i < 5; i++) {
-        futures.add(() async {
-          final response = await client.get('helloworld');
-          expect(response.statusCode, equals(200));
-          expect(response.body, contains('Hello from Dart Functions!'));
-        }());
-      }
+        for (var i = 0; i < 5; i++) {
+          futures.add(() async {
+            final response = await client.get('helloworld');
+            expect(response.statusCode, equals(200));
+            expect(response.body, contains('Hello from Dart Functions!'));
+          }());
+        }
 
-      await Future.wait(futures);
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        await Future.wait(futures);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
 
     test('function is discoverable via emulator', () async {
       print('GET ${client.baseUrl}/helloworld');

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -79,26 +79,22 @@ void runHttpsOnRequestTests(
       expect(response.statusCode, equals(404));
     });
 
-    test(
-      'handles multiple concurrent requests',
-      () async {
-        // Reduced from 10 to 5 requests to avoid CI timeout issues
-        // The emulator spawns separate workers which can be slow in CI
-        print('Making 5 concurrent requests...');
-        final futures = <Future<void>>[];
+    test('handles multiple concurrent requests', () async {
+      // Reduced from 10 to 5 requests to avoid CI timeout issues
+      // The emulator spawns separate workers which can be slow in CI
+      print('Making 5 concurrent requests...');
+      final futures = <Future<void>>[];
 
-        for (var i = 0; i < 5; i++) {
-          futures.add(() async {
-            final response = await client.get('helloworld');
-            expect(response.statusCode, equals(200));
-            expect(response.body, contains('Hello from Dart Functions!'));
-          }());
-        }
+      for (var i = 0; i < 5; i++) {
+        futures.add(() async {
+          final response = await client.get('helloworld');
+          expect(response.statusCode, equals(200));
+          expect(response.body, contains('Hello from Dart Functions!'));
+        }());
+      }
 
-        await Future.wait(futures);
-      },
-      timeout: const Timeout(Duration(seconds: 60)),
-    );
+      await Future.wait(futures);
+    }, timeout: const Timeout(Duration(seconds: 60)));
 
     test('function is discoverable via emulator', () async {
       print('GET ${client.baseUrl}/helloworld');
@@ -126,7 +122,7 @@ void runHttpsOnRequestTests(
 
         // Generic INTERNAL error is returned
         expect(error['status'], equals('INTERNAL'));
-        expect(error['message'], equals('An unexpected error occurred.'));
+        expect(error['message'], equals('Internal Server Error'));
 
         // Sensitive details must NOT appear anywhere in the response
         expect(response.body, isNot(contains('SECRET_DATA')));
@@ -167,7 +163,7 @@ void runHttpsOnRequestTests(
 
         // Generic INTERNAL error is returned
         expect(error['status'], equals('INTERNAL'));
-        expect(error['message'], equals('An unexpected error occurred.'));
+        expect(error['message'], equals('Internal Server Error'));
 
         // No internal details leaked (no type names, stack traces, file paths)
         expect(response.body, isNot(contains('TypeError')));

--- a/test/e2e/tests/https_onrequest_tests.dart
+++ b/test/e2e/tests/https_onrequest_tests.dart
@@ -141,10 +141,7 @@ void runHttpsOnRequestTests(
           reason: 'The actual error should be logged server-side for debugging',
         );
 
-        print(
-          '✓ Verified: 500 INTERNAL returned, no password leaked to client, '
-          'error logged server-side',
-        );
+        print('✓ Verified: 500 INTERNAL returned, error logged');
       },
     );
 
@@ -171,10 +168,7 @@ void runHttpsOnRequestTests(
         expect(response.body, isNot(contains('.dart')));
         expect(response.body, isNot(contains('type ')));
 
-        print(
-          '✓ Verified: unexpected runtime crash returns generic 500, '
-          'no internals leaked',
-        );
+        print('✓ Verified: unexpected crash returns generic 500');
       },
     );
 

--- a/test/unit/error_logging_test.dart
+++ b/test/unit/error_logging_test.dart
@@ -17,79 +17,18 @@
 import 'dart:convert';
 
 import 'package:firebase_functions/src/common/environment.dart';
-import 'package:firebase_functions/src/common/utilities.dart';
 import 'package:firebase_functions/src/firebase.dart';
 import 'package:firebase_functions/src/https/error.dart';
 import 'package:firebase_functions/src/https/https_namespace.dart';
 import 'package:firebase_functions/src/pubsub/pubsub_namespace.dart';
 import 'package:firebase_functions/src/scheduler/scheduler_namespace.dart';
+import 'package:firebase_functions/src/server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
 void main() {
   setUpAll(() {
     FirebaseEnv.mockEnvironment = {'FIREBASE_PROJECT': 'demo-test'};
-  });
-
-  group('Error logging utilities', () {
-    group('logInternalError', () {
-      test('returns InternalError', () {
-        final result = logInternalError(
-          Exception('secret db password: abc123'),
-          StackTrace.current,
-        );
-        expect(result, isA<InternalError>());
-        expect(result.code, FunctionsErrorCode.internal);
-      });
-
-      test('does not include error details in the HTTP response', () {
-        final error = logInternalError(
-          Exception('secret db password: abc123'),
-          StackTrace.current,
-        );
-        final response = error.toShelfResponse();
-        // Synchronously read the body from the response
-        // The response wraps the body as a shelf body
-        expect(response.statusCode, 500);
-
-        // Verify the JSON body contains generic message, not the secret
-        return response.readAsString().then((body) {
-          final json = jsonDecode(body) as Map<String, dynamic>;
-          expect(json['error']['status'], 'INTERNAL');
-          expect(json['error']['message'], 'An unexpected error occurred.');
-          expect(body, isNot(contains('secret db password')));
-          expect(body, isNot(contains('abc123')));
-        });
-      });
-    });
-
-    group('logEventHandlerError', () {
-      test('returns 500 response', () {
-        final response = logEventHandlerError(
-          Exception('secret api key: xyz789'),
-          StackTrace.current,
-        );
-        expect(response.statusCode, 500);
-      });
-
-      test('does not include error details in the response body', () async {
-        final response = logEventHandlerError(
-          Exception('secret api key: xyz789'),
-          StackTrace.current,
-        );
-        final body = await response.readAsString();
-        expect(body, isNot(contains('secret api key')));
-        expect(body, isNot(contains('xyz789')));
-      });
-    });
-
-    group('_logError (via logInternalError)', () {
-      test('logs error and terse stack trace to stderr', () {
-        // We can't directly test the global logger, but we can test
-        // Trace.terse formatting indirectly by verifying our utility logic.
-        // The actual logging is tested via integration below.
-      });
-    });
   });
 
   group('HTTPS handler error logging integration', () {
@@ -102,28 +41,21 @@ void main() {
     });
 
     test(
-      'onRequest: unexpected error returns INTERNAL without details',
+      'onRequest: unexpected error returns 500 without sensitive details',
       () async {
         https.onRequest(name: 'crashEndpoint', (request) async {
           throw StateError('sensitive: connection string is postgres://...');
         });
 
-        final func = firebase.functions.firstWhere(
-          (f) => f.name == 'crashendpoint',
-        );
+        final handler = createTestHandler(firebase);
         final request = Request(
           'GET',
           Uri.parse('http://localhost/crashendpoint'),
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 500);
         final body = await response.readAsString();
-        final json = jsonDecode(body) as Map<String, dynamic>;
-
-        // Error response is generic
-        expect(json['error']['status'], 'INTERNAL');
-        expect(json['error']['message'], 'An unexpected error occurred.');
 
         // Sensitive details are NOT in the response
         expect(body, isNot(contains('postgres://')));
@@ -136,9 +68,9 @@ void main() {
         throw NotFoundError('User 42 not found');
       });
 
-      final func = firebase.functions.firstWhere((f) => f.name == 'knownerror');
+      final handler = createTestHandler(firebase);
       final request = Request('GET', Uri.parse('http://localhost/knownerror'));
-      final response = await func.handler(request);
+      final response = await handler(request);
 
       expect(response.statusCode, 404);
       final body = await response.readAsString();
@@ -163,11 +95,6 @@ void main() {
         throw Exception('sensitive: api key is sk-12345');
       });
 
-      final func = firebase.functions.firstWhere(
-        (f) => f.name == 'onmessagepublished-testtopic',
-      );
-
-      // Send a valid Pub/Sub CloudEvent
       final cloudEvent = {
         'specversion': '1.0',
         'id': 'test-id',
@@ -186,13 +113,14 @@ void main() {
         },
       };
 
+      final handler = createTestHandler(firebase);
       final request = Request(
         'POST',
         Uri.parse('http://localhost/onmessagepublished-testtopic'),
         body: jsonEncode(cloudEvent),
         headers: {'content-type': 'application/json'},
       );
-      final response = await func.handler(request);
+      final response = await handler(request);
 
       expect(response.statusCode, 500);
       final body = await response.readAsString();
@@ -208,16 +136,13 @@ void main() {
         throw Exception('sensitive: db password is hunter2');
       });
 
-      final func = firebase.functions.firstWhere(
-        (f) => f.name == 'onschedule-0-0',
-      );
-
+      final handler = createTestHandler(firebase);
       final request = Request(
         'POST',
         Uri.parse('http://localhost/onschedule-0-0'),
         headers: {'x-cloudscheduler-scheduletime': '2024-01-01T00:00:00Z'},
       );
-      final response = await func.handler(request);
+      final response = await handler(request);
 
       expect(response.statusCode, 500);
       final body = await response.readAsString();

--- a/test/unit/https_namespace_test.dart
+++ b/test/unit/https_namespace_test.dart
@@ -26,6 +26,8 @@ import 'package:firebase_functions/src/https/options.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'shared_utils.dart';
+
 // Helper to find function by name (uses kebab-case Cloud Run ID)
 FirebaseFunctionDeclaration? _findFunction(Firebase firebase, String name) {
   try {
@@ -101,17 +103,19 @@ void main() {
           throw Exception('Unexpected crash');
         });
 
-        final func = _findFunction(firebase, 'crashfunction')!;
+        final handler = findHandler(firebase, 'crashfunction');
         final request = Request(
           'GET',
           Uri.parse('http://localhost/crashfunction'),
+          headers: {'accept': 'application/json'},
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 500);
-        expect(response.headers['Content-Type'], 'application/json');
+        expect(response.headers['content-type'], contains('application/json'));
 
-        final body = jsonDecode(await response.readAsString());
+        final body =
+            jsonDecode(await response.readAsString()) as Map<String, dynamic>;
         expect(body['error']['status'], 'INTERNAL');
       });
 

--- a/test/unit/remote_config_test.dart
+++ b/test/unit/remote_config_test.dart
@@ -22,6 +22,8 @@ import 'package:firebase_functions/src/remote_config/remote_config_namespace.dar
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'shared_utils.dart';
+
 // Helper to find function by name
 FirebaseFunctionDeclaration? _findFunction(Firebase firebase, String name) {
   try {
@@ -226,8 +228,8 @@ void main() {
           throw Exception('Handler error');
         });
 
-        final func = _findFunction(firebase, 'onconfigupdated')!;
-        final response = await func.handler(_createRemoteConfigRequest());
+        final handler = findHandler(firebase, 'onconfigupdated');
+        final response = await handler(_createRemoteConfigRequest());
 
         expect(response.statusCode, 500);
         final body = await response.readAsString();

--- a/test/unit/scheduler_namespace_test.dart
+++ b/test/unit/scheduler_namespace_test.dart
@@ -21,6 +21,8 @@ import 'package:firebase_functions/src/scheduler/scheduler_namespace.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'shared_utils.dart';
+
 // Helper to find function by name
 FirebaseFunctionDeclaration? _findFunction(Firebase firebase, String name) {
   try {
@@ -154,13 +156,13 @@ void main() {
           throw Exception('Handler error');
         });
 
-        final func = _findFunction(firebase, 'onschedule-0-0')!;
+        final handler = findHandler(firebase, 'onschedule-0-0');
         final request = Request(
           'POST',
           Uri.parse('http://localhost/onschedule-0-0'),
           headers: {'x-cloudscheduler-scheduletime': '2024-01-01T00:00:00Z'},
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 500);
         final body = await response.readAsString();

--- a/test/unit/shared_utils.dart
+++ b/test/unit/shared_utils.dart
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:firebase_functions/src/firebase.dart';
+import 'package:firebase_functions/src/server.dart';
+import 'package:shelf/shelf.dart';
+
+/// Finds a registered function declaration by name.
+FirebaseFunctionDeclaration findFunction(Firebase firebase, String name) {
+  return firebase.functions.firstWhere((f) => f.name == name.toLowerCase());
+}
+
+/// Creates a handler for testing error handling via full middleware pipeline.
+Handler findHandler(Firebase firebase, String name) {
+  final testHandler = createTestHandler(firebase);
+  return (request) {
+    return testHandler(
+      Request(
+        request.method,
+        Uri.parse('http://localhost/${name.toLowerCase()}'),
+        headers: request.headers,
+        body: request.read(),
+        context: request.context,
+      ),
+    );
+  };
+}

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -302,6 +302,19 @@ void main() {
         expect(body, isNot(contains('Handler error')));
       });
 
+      test('returns 500 when handler throws FormatException', () async {
+        storage.onObjectFinalized(bucket: 'my-bucket', (event) async {
+          throw const FormatException('User-level format error');
+        });
+
+        final handler = findHandler(firebase, 'onobjectfinalized-mybucket');
+        final response = await handler(_createStorageRequest());
+
+        expect(response.statusCode, 500);
+        final body = await response.readAsString();
+        expect(body, isNot(contains('Invalid CloudEvent')));
+      });
+
       test('returns 400 for invalid CloudEvent', () async {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -22,6 +22,8 @@ import 'package:firebase_functions/src/storage/storage_object_data.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'shared_utils.dart';
+
 // Helper to find function by name
 FirebaseFunctionDeclaration? _findFunction(Firebase firebase, String name) {
   try {
@@ -292,8 +294,8 @@ void main() {
           throw Exception('Handler error');
         });
 
-        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
-        final response = await func.handler(_createStorageRequest());
+        final handler = findHandler(firebase, 'onobjectfinalized-mybucket');
+        final response = await handler(_createStorageRequest());
 
         expect(response.statusCode, 500);
         final body = await response.readAsString();


### PR DESCRIPTION
Remove redundant try-catch blocks and manual logEventHandlerError/logInternalError calls across function namespace handlers, delegating exception catching and structured error logging to google_cloud_shelf middleware.

### Context
runFunctions uses createLoggingMiddleware from google_cloud_shelf in the Shelf pipeline. This middleware automatically catches unhandled handler exceptions, correlates Cloud Trace IDs, formats structured Cloud Logging entries, and performs content-negotiation to return structured JSON responses when appropriate. Manual try-catch blocks in each namespace were redundant boilerplate.

### Summary of Changes
- Removed redundant try-catch blocks across 13 namespace files (alerts, database, firestore, pubsub, storage, scheduler, etc.).
- Removed dead logEventHandlerError, logInternalError, _logError functions and package:stack_trace import from lib/src/common/utilities.dart.
- Updated createTestHandler in lib/src/server.dart to apply createLoggingMiddleware so tests exercise the full pipeline.
- Added test/unit/shared_utils.dart helper and updated unit tests (error_logging_test.dart, https_namespace_test.dart, remote_config_test.dart, scheduler_namespace_test.dart, storage_test.dart).

Fixes #211 
