### PR TITLE
refactor: replace manual Response(4xx/5xx) with HttpResponseException

### DIFF
--- a/lib/src/alerts/alerts_namespace.dart
+++ b/lib/src/alerts/alerts_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -91,15 +92,18 @@ class AlertsNamespace extends FunctionsNamespace {
         final json = await parseAndValidateCloudEvent(request);
 
         if (!_isAlertEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for alerts: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for alerts: ${json['type']}',
           );
         }
 
         event = AlertEvent<T>.fromJson(json, fromJson);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/lib/src/alerts/app_distribution_namespace.dart
+++ b/lib/src/alerts/app_distribution_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -73,15 +74,18 @@ class AppDistributionNamespace {
         final json = await parseAndValidateCloudEvent(request);
 
         if (!_isAlertEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for alerts: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for alerts: ${json['type']}',
           );
         }
 
         event = AlertEvent<T>.fromJson(json, payloadDecoder);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/lib/src/alerts/billing_namespace.dart
+++ b/lib/src/alerts/billing_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -74,15 +75,18 @@ class BillingNamespace {
         final json = await parseAndValidateCloudEvent(request);
 
         if (!_isAlertEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for alerts: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for alerts: ${json['type']}',
           );
         }
 
         event = AlertEvent<T>.fromJson(json, payloadDecoder);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/lib/src/alerts/crashlytics_namespace.dart
+++ b/lib/src/alerts/crashlytics_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -130,15 +131,18 @@ class CrashlyticsNamespace {
         final json = await parseAndValidateCloudEvent(request);
 
         if (!_isAlertEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for alerts: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for alerts: ${json['type']}',
           );
         }
 
         event = AlertEvent<T>.fromJson(json, payloadDecoder);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/lib/src/alerts/performance_namespace.dart
+++ b/lib/src/alerts/performance_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -59,15 +60,18 @@ class PerformanceNamespace {
         final json = await parseAndValidateCloudEvent(request);
 
         if (!_isAlertEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for alerts: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for alerts: ${json['type']}',
           );
         }
 
         event = AlertEvent<T>.fromJson(json, payloadDecoder);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/lib/src/database/database_namespace.dart
+++ b/lib/src/database/database_namespace.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -87,9 +88,9 @@ class DatabaseNamespace extends FunctionsNamespace {
           final ceType = request.headers['ce-type'];
 
           if (ceType != null && !_isCreatedEvent(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Database onValueCreated: $ceType',
+            throw HttpResponseException.badRequest(
+              message:
+                  'Invalid event type for Database onValueCreated: $ceType',
             );
           }
 
@@ -142,9 +143,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           final json = await parseAndValidateCloudEvent(request);
 
           if (!_isCreatedEvent(json['type'] as String)) {
-            return Response(
-              400,
-              body:
+            throw HttpResponseException.badRequest(
+              message:
                   'Invalid event type for Database onValueCreated: ${json['type']}',
             );
           }
@@ -178,8 +178,12 @@ class DatabaseNamespace extends FunctionsNamespace {
             params: params,
           );
         }
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);
@@ -230,9 +234,9 @@ class DatabaseNamespace extends FunctionsNamespace {
           final ceType = request.headers['ce-type'];
 
           if (ceType != null && !_isUpdatedEvent(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Database onValueUpdated: $ceType',
+            throw HttpResponseException.badRequest(
+              message:
+                  'Invalid event type for Database onValueUpdated: $ceType',
             );
           }
 
@@ -298,9 +302,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           final json = await parseAndValidateCloudEvent(request);
 
           if (!_isUpdatedEvent(json['type'] as String)) {
-            return Response(
-              400,
-              body:
+            throw HttpResponseException.badRequest(
+              message:
                   'Invalid event type for Database onValueUpdated: ${json['type']}',
             );
           }
@@ -345,8 +348,12 @@ class DatabaseNamespace extends FunctionsNamespace {
             params: params,
           );
         }
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);
@@ -394,9 +401,9 @@ class DatabaseNamespace extends FunctionsNamespace {
           final ceType = request.headers['ce-type'];
 
           if (ceType != null && !_isDeletedEvent(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Database onValueDeleted: $ceType',
+            throw HttpResponseException.badRequest(
+              message:
+                  'Invalid event type for Database onValueDeleted: $ceType',
             );
           }
 
@@ -449,9 +456,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           final json = await parseAndValidateCloudEvent(request);
 
           if (!_isDeletedEvent(json['type'] as String)) {
-            return Response(
-              400,
-              body:
+            throw HttpResponseException.badRequest(
+              message:
                   'Invalid event type for Database onValueDeleted: ${json['type']}',
             );
           }
@@ -485,8 +491,12 @@ class DatabaseNamespace extends FunctionsNamespace {
             params: params,
           );
         }
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);
@@ -545,9 +555,9 @@ class DatabaseNamespace extends FunctionsNamespace {
           final ceType = request.headers['ce-type'];
 
           if (ceType != null && !_isWrittenEvent(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Database onValueWritten: $ceType',
+            throw HttpResponseException.badRequest(
+              message:
+                  'Invalid event type for Database onValueWritten: $ceType',
             );
           }
 
@@ -614,9 +624,8 @@ class DatabaseNamespace extends FunctionsNamespace {
           final json = await parseAndValidateCloudEvent(request);
 
           if (!_isWrittenEvent(json['type'] as String)) {
-            return Response(
-              400,
-              body:
+            throw HttpResponseException.badRequest(
+              message:
                   'Invalid event type for Database onValueWritten: ${json['type']}',
             );
           }
@@ -661,8 +670,12 @@ class DatabaseNamespace extends FunctionsNamespace {
             params: params,
           );
         }
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/lib/src/eventarc/eventarc_namespace.dart
+++ b/lib/src/eventarc/eventarc_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -64,8 +65,12 @@ class EventarcNamespace extends FunctionsNamespace {
 
         // Parse CloudEvent with generic data
         event = CloudEvent<Object>.fromJson(json, (data) => data);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       // Execute handler

--- a/lib/src/firestore/firestore_namespace.dart
+++ b/lib/src/firestore/firestore_namespace.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -453,15 +454,16 @@ class FirestoreNamespace extends FunctionsNamespace {
           final ceType = request.headers['ce-type'];
 
           if (ceType != null && !validateEventType(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Firestore $methodName: $ceType',
+            throw HttpResponseException.badRequest(
+              message: 'Invalid event type for Firestore $methodName: $ceType',
             );
           }
 
           final headers = _extractHeaders(request);
           if (headers == null) {
-            return Response(400, body: 'Missing required CloudEvent headers');
+            throw HttpResponseException.badRequest(
+              message: 'Missing required CloudEvent headers',
+            );
           }
 
           final params = _extractParams(document, headers.documentPath);
@@ -529,9 +531,8 @@ class FirestoreNamespace extends FunctionsNamespace {
             final json = await parseAndValidateCloudEvent(request);
 
             if (!validateEventType(json['type'] as String)) {
-              return Response(
-                400,
-                body:
+              throw HttpResponseException.badRequest(
+                message:
                     'Invalid event type for Firestore $methodName: ${json['type']}',
               );
             }
@@ -577,15 +578,18 @@ class FirestoreNamespace extends FunctionsNamespace {
                       ))(event);
             }
           } else {
-            return Response(
-              501,
-              body:
+            throw HttpResponseException.notImplemented(
+              message:
                   'Structured CloudEvent mode not yet supported for $methodName',
             );
           }
         }
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await executeHandler();
@@ -617,15 +621,16 @@ class FirestoreNamespace extends FunctionsNamespace {
           final ceType = request.headers['ce-type'];
 
           if (ceType != null && !validateEventType(ceType)) {
-            return Response(
-              400,
-              body: 'Invalid event type for Firestore $methodName: $ceType',
+            throw HttpResponseException.badRequest(
+              message: 'Invalid event type for Firestore $methodName: $ceType',
             );
           }
 
           final headers = _extractHeaders(request);
           if (headers == null) {
-            return Response(400, body: 'Missing required CloudEvent headers');
+            throw HttpResponseException.badRequest(
+              message: 'Missing required CloudEvent headers',
+            );
           }
 
           final params = _extractParams(document, headers.documentPath);
@@ -687,14 +692,17 @@ class FirestoreNamespace extends FunctionsNamespace {
                     ))(event);
           }
         } else {
-          return Response(
-            501,
-            body:
+          throw HttpResponseException.notImplemented(
+            message:
                 'Structured CloudEvent mode not yet supported for $methodName',
           );
         }
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await executeHandler();

--- a/lib/src/pubsub/pubsub_namespace.dart
+++ b/lib/src/pubsub/pubsub_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -61,9 +62,8 @@ class PubSubNamespace extends FunctionsNamespace {
 
         // Verify it's a Pub/Sub event
         if (!_isPubSubEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for Pub/Sub: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for Pub/Sub: ${json['type']}',
           );
         }
 
@@ -72,8 +72,12 @@ class PubSubNamespace extends FunctionsNamespace {
           json,
           PubsubMessage.fromJson,
         );
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       // Execute handler

--- a/lib/src/remote_config/remote_config_namespace.dart
+++ b/lib/src/remote_config/remote_config_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -57,9 +58,8 @@ class RemoteConfigNamespace extends FunctionsNamespace {
 
         // Verify it's a Remote Config event
         if (!_isRemoteConfigEvent(json['type'] as String)) {
-          return Response(
-            400,
-            body: 'Invalid event type for Remote Config: ${json['type']}',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for Remote Config: ${json['type']}',
           );
         }
 
@@ -68,8 +68,12 @@ class RemoteConfigNamespace extends FunctionsNamespace {
           json,
           ConfigUpdateData.fromJson,
         );
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       // Execute handler

--- a/lib/src/storage/storage_namespace.dart
+++ b/lib/src/storage/storage_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -147,16 +148,19 @@ class StorageNamespace extends FunctionsNamespace {
         // Verify it's the expected Storage event type
         final eventType = json['type'] as String;
         if (!_isStorageEvent(eventType)) {
-          return Response(
-            400,
-            body: 'Invalid event type for Storage: $eventType',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for Storage: $eventType',
           );
         }
 
         // Parse CloudEvent with StorageObjectData
         event = StorageEvent.fromJson(json);
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       // Execute handler

--- a/lib/src/tasks/tasks_namespace.dart
+++ b/lib/src/tasks/tasks_namespace.dart
@@ -14,14 +14,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
-import 'package:stack_trace/stack_trace.dart' show Trace;
-
-import '../../logger.dart' as logger;
 import '../firebase.dart';
 import 'options.dart';
 import 'task_request.dart';
@@ -133,13 +130,10 @@ class TasksNamespace extends FunctionsNamespace {
         // Return 204 No Content (matching Node.js behavior)
         return Response(204);
       } catch (e, stackTrace) {
-        logger.error('$e\n${Trace.from(stackTrace).terse}');
-        return Response(
-          500,
-          body: jsonEncode({
-            'error': {'status': 'INTERNAL', 'message': 'INTERNAL'},
-          }),
-          headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+        throw HttpResponseException.internalServerError(
+          message: 'INTERNAL',
+          innerError: e,
+          innerStack: stackTrace,
         );
       }
     });

--- a/lib/src/test_lab/test_lab_namespace.dart
+++ b/lib/src/test_lab/test_lab_namespace.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
@@ -55,9 +56,8 @@ class TestLabNamespace extends FunctionsNamespace {
 
         final eventType = json['type'] as String;
         if (eventType != _eventType) {
-          return Response(
-            400,
-            body: 'Invalid event type for Test Lab: $eventType',
+          throw HttpResponseException.badRequest(
+            message: 'Invalid event type for Test Lab: $eventType',
           );
         }
 
@@ -65,8 +65,12 @@ class TestLabNamespace extends FunctionsNamespace {
           json,
           TestMatrixCompletedData.fromJson,
         );
-      } on FormatException catch (e) {
-        return Response(400, body: 'Invalid CloudEvent: ${e.message}');
+      } on FormatException catch (e, stackTrace) {
+        throw HttpResponseException.badRequest(
+          message: 'Invalid CloudEvent: ${e.message}',
+          innerError: e,
+          innerStack: stackTrace,
+        );
       }
 
       await handler(event);

--- a/test/unit/remote_config_test.dart
+++ b/test/unit/remote_config_test.dart
@@ -239,14 +239,14 @@ void main() {
       test('returns 400 for invalid CloudEvent', () async {
         remoteConfig.onConfigUpdated((event) async {});
 
-        final func = _findFunction(firebase, 'onconfigupdated')!;
+        final handler = findHandler(firebase, 'onconfigupdated');
         final request = Request(
           'POST',
           Uri.parse('http://localhost/onconfigupdated'),
           body: 'not json',
           headers: {'content-type': 'application/json'},
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 400);
       });
@@ -254,7 +254,7 @@ void main() {
       test('returns 400 for wrong event type', () async {
         remoteConfig.onConfigUpdated((event) async {});
 
-        final func = _findFunction(firebase, 'onconfigupdated')!;
+        final handler = findHandler(firebase, 'onconfigupdated');
         final request = Request(
           'POST',
           Uri.parse('http://localhost/onconfigupdated'),
@@ -268,7 +268,7 @@ void main() {
           }),
           headers: {'content-type': 'application/json'},
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 400);
         final body = await response.readAsString();

--- a/test/unit/storage_test.dart
+++ b/test/unit/storage_test.dart
@@ -318,14 +318,14 @@ void main() {
       test('returns 400 for invalid CloudEvent', () async {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
-        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
+        final handler = findHandler(firebase, 'onobjectfinalized-mybucket');
         final request = Request(
           'POST',
           Uri.parse('http://localhost/onobjectfinalized-mybucket'),
           body: 'not json',
           headers: {'content-type': 'application/json'},
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 400);
       });
@@ -333,7 +333,7 @@ void main() {
       test('returns 400 for wrong event type', () async {
         storage.onObjectFinalized(bucket: 'my-bucket', (event) async {});
 
-        final func = _findFunction(firebase, 'onobjectfinalized-mybucket')!;
+        final handler = findHandler(firebase, 'onobjectfinalized-mybucket');
         final request = Request(
           'POST',
           Uri.parse('http://localhost/onobjectfinalized-mybucket'),
@@ -352,7 +352,7 @@ void main() {
           }),
           headers: {'content-type': 'application/json'},
         );
-        final response = await func.handler(request);
+        final response = await handler(request);
 
         expect(response.statusCode, 400);
         final body = await response.readAsString();


### PR DESCRIPTION
Manual `Response(4xx)` and `Response(5xx)` returns across event namespaces are replaced with throwing `HttpResponseException` from `package:google_cloud_shelf`. This ensures that `createLoggingMiddleware` records warning and error logs with full stack traces, inner errors, and trace correlation in Cloud Logging.

Summary of Changes:
- Replace manual `Response(400)` and `Response(500)` returns across 13 namespace files (`alerts`, `app_distribution`, `billing`, `crashlytics`, `performance`, `database`, `eventarc`, `firestore`, `pubsub`, `remote_config`, `storage`, `tasks`, `test_lab`) with throwing `HttpResponseException`.
- Replace manual 501 responses in `firestore_namespace.dart` with throwing `HttpResponseException.notImplemented`.
- Update 400 error unit tests in `storage_test.dart` and `remote_config_test.dart` to use `findHandler` for testing via the full middleware pipeline.

Fixes #215
