### PR TITLE
fix: migrate builder AST usage to analyzer 13+ API, bump analyzer/sdk floor

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -50,5 +50,4 @@ linter:
     - sort_constructors_first
     - sort_unnamed_constructors_first
     - unnecessary_ignore
-    - use_if_null_to_convert_nulls_to_bools
     - use_string_buffers

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -433,7 +433,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
             }
           } else {
             final nameArg = args.first;
-            final paramName = _extractStringLiteral(nameArg);
+            final paramName = _extractStringLiteral(
+              nameArg is Expression ? nameArg : null,
+            );
             if (paramName != null) {
               // Map variable name to actual param name
               _variableToParamName[variable.name.lexeme] = paramName;
@@ -893,9 +895,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     String fieldName,
   ) {
     final arg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == fieldName)
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == fieldName)
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (arg is! SetOrMapLiteral || !arg.isMap) return null;
@@ -919,9 +921,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     InstanceCreationExpression node,
   ) {
     final retryConfigArg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'retryConfig')
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == 'retryConfig')
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (retryConfigArg is! InstanceCreationExpression) return null;
@@ -929,10 +931,10 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     final config = <String, dynamic>{};
 
     for (final arg in retryConfigArg.argumentList.arguments) {
-      if (arg is! NamedExpression) continue;
+      if (arg is! NamedArgument) continue;
 
-      final fieldName = arg.name.label.name;
-      final value = _extractRetryConfigValue(arg.expression);
+      final fieldName = arg.name.lexeme;
+      final value = _extractRetryConfigValue(arg.argumentExpression);
       if (value != null) {
         config[fieldName] = value;
       }
@@ -946,9 +948,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     InstanceCreationExpression node,
   ) {
     final rateLimitsArg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'rateLimits')
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == 'rateLimits')
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (rateLimitsArg is! InstanceCreationExpression) return null;
@@ -956,10 +958,10 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     final config = <String, dynamic>{};
 
     for (final arg in rateLimitsArg.argumentList.arguments) {
-      if (arg is! NamedExpression) continue;
+      if (arg is! NamedArgument) continue;
 
-      final fieldName = arg.name.label.name;
-      final value = _extractRetryConfigValue(arg.expression);
+      final fieldName = arg.name.lexeme;
+      final value = _extractRetryConfigValue(arg.argumentExpression);
       if (value != null) {
         config[fieldName] = value;
       }
@@ -971,9 +973,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
   /// Extracts timeZone from ScheduleOptions.
   String? _extractSchedulerTimeZone(InstanceCreationExpression node) {
     final timeZoneArg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'timeZone')
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == 'timeZone')
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (timeZoneArg is InstanceCreationExpression) {
@@ -989,9 +991,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
   /// Extracts RetryConfig from ScheduleOptions.
   Map<String, dynamic>? _extractRetryConfig(InstanceCreationExpression node) {
     final retryConfigArg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'retryConfig')
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == 'retryConfig')
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (retryConfigArg is! InstanceCreationExpression) return null;
@@ -999,10 +1001,10 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     final config = <String, dynamic>{};
 
     for (final arg in retryConfigArg.argumentList.arguments) {
-      if (arg is! NamedExpression) continue;
+      if (arg is! NamedArgument) continue;
 
-      final fieldName = arg.name.label.name;
-      final value = _extractRetryConfigValue(arg.expression);
+      final fieldName = arg.name.lexeme;
+      final value = _extractRetryConfigValue(arg.argumentExpression);
       if (value != null) {
         config[fieldName] = value;
       }
@@ -1027,9 +1029,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
   /// Extracts a boolean field from an InstanceCreationExpression.
   bool? _extractBoolField(InstanceCreationExpression node, String fieldName) {
     final arg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == fieldName)
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == fieldName)
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (arg is BooleanLiteral) {
@@ -1076,7 +1078,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
   }
 
   /// Common logic for extracting parameter definitions from arguments.
-  void _extractParamFromArgs(NodeList<Expression> args, String functionName) {
+  void _extractParamFromArgs(NodeList<Argument> args, String functionName) {
     if (args.isEmpty) return;
 
     String? paramName;
@@ -1110,7 +1112,7 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     } else {
       // Standard parameter definitions: defineXxx('NAME', [ParamOptions])
       final nameArg = args.first;
-      paramName = _extractStringLiteral(nameArg);
+      paramName = _extractStringLiteral(nameArg is Expression ? nameArg : null);
 
       // Second argument is optional ParamOptions (not used for secrets)
       if (args.length > 1 && args[1] is InstanceCreationExpression) {
@@ -1158,9 +1160,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
   /// Extracts the defaultValue field.
   Object? _extractDefaultValue(InstanceCreationExpression node) {
     final defaultValueArg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'defaultValue')
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == 'defaultValue')
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     if (defaultValueArg == null) return null;
@@ -1174,9 +1176,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
     String fieldName,
   ) {
     final arg = node.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == fieldName)
-        .map((e) => e.expression)
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == fieldName)
+        .map((e) => e.argumentExpression)
         .firstOrNull;
 
     return _extractStringLiteral(arg);
@@ -1186,9 +1188,9 @@ class _FirebaseFunctionsVisitor extends RecursiveAstVisitor<void> {
 extension on MethodInvocation {
   /// Finds a named argument in a method invocation.
   Expression? findNamedArg(String name) => argumentList.arguments
-      .whereType<NamedExpression>()
-      .where((e) => e.name.label.name == name)
-      .map((e) => e.expression)
+      .whereType<NamedArgument>()
+      .where((e) => e.name.lexeme == name)
+      .map((e) => e.argumentExpression)
       .firstOrNull;
 
   String? extractLiteralForArg(String name) =>

--- a/lib/src/builder/spec.dart
+++ b/lib/src/builder/spec.dart
@@ -131,10 +131,10 @@ class EndpointSpec {
     final result = <String, dynamic>{};
 
     for (final arg in options.argumentList.arguments) {
-      if (arg is! NamedExpression) continue;
+      if (arg is! NamedArgument) continue;
 
-      final name = arg.name.label.name;
-      final expr = arg.expression;
+      final name = arg.name.lexeme;
+      final expr = arg.argumentExpression;
 
       // Helper to reduce boilerplate: only adds to map if value exists
       void add(String key, dynamic Function(Expression expr) func) {
@@ -285,7 +285,7 @@ class EndpointSpec {
   }
 
   /// Extracts a literal region option from an enum expression.
-  Object? _extractRegionLiteral(Expression? expression) {
+  Object? _extractRegionLiteral(Argument? expression) {
     final enumName = _extractEnumValueName(expression);
     if (enumName != null) {
       final regionString = _regionEnumToString(enumName);
@@ -515,7 +515,7 @@ class EndpointSpec {
 
   /// Extracts a CEL expression from an expression argument.
   /// Handles thenElse (ternary) expressions on boolean params.
-  String? _extractCelExpression(Expression? expression) {
+  String? _extractCelExpression(Argument? expression) {
     // Handle method invocation like: isProduction.thenElse(2048, 512)
     if (expression is MethodInvocation) {
       final target = expression.target;
@@ -543,7 +543,7 @@ class EndpointSpec {
   }
 
   /// Extracts a literal value from an expression.
-  Object? _extractLiteralValue(Expression expression) => switch (expression) {
+  Object? _extractLiteralValue(Argument expression) => switch (expression) {
     StringLiteral() => '"${expression.stringValue}"',
     IntegerLiteral() => expression.value,
     DoubleLiteral() => expression.value,
@@ -554,7 +554,7 @@ class EndpointSpec {
   /// Extracts arguments from constructor-like calls. When code is unresolved,
   /// wrappers such as `DeployOption(...)` can appear as invocations instead of
   /// [InstanceCreationExpression] nodes.
-  NodeList<Expression>? _extractCallArguments(
+  NodeList<Argument>? _extractCallArguments(
     Expression expression,
   ) => switch (expression) {
     InstanceCreationExpression(:final argumentList) => argumentList.arguments,
@@ -573,7 +573,7 @@ class EndpointSpec {
   /// Extracts an enum value name from an expression, handling both
   /// fully-qualified (`SupportedRegion.europeWest3`) and shorthand
   /// (`.europeWest3`) syntax.
-  String? _extractEnumValueName(Expression? expression) => switch (expression) {
+  String? _extractEnumValueName(Argument? expression) => switch (expression) {
     PrefixedIdentifier() => expression.identifier.name,
     SimpleIdentifier() => expression.name,
     PropertyAccess() => expression.propertyName.name,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ version: 0.7.0-wip
 repository: https://github.com/firebase/firebase-functions-dart
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.11.0
 
 workspace:
   - example/hosting
@@ -41,7 +41,7 @@ workspace:
   - test/fixtures/dart_reference
 
 dependencies:
-  analyzer: '>=10.0.1 <13.0.0'
+  analyzer: '>=13.0.0 <15.0.0'
   build: ^4.0.4
   dart_jsonwebtoken: ^3.2.0
   firebase_admin_sdk: ^0.5.2


### PR DESCRIPTION
Closes #227.

`analyzer` was capped at `<13.0.0` because the spec builder's AST parsing relied on APIs analyzer 13 removed — `NamedExpression` (now `NamedArgument`) and `ArgumentList.arguments` returning `NodeList<Expression>` (now `NodeList<Argument>`). This collided with packages like `riverpod_generator`, which requires `analyzer: ^13.0.0`, making `firebase_functions` unresolvable alongside it.

Migrates `builder.dart` and `spec.dart` to the new AST shape and widens the constraint to `analyzer: '>=13.0.0 <15.0.0'`. Also bumps the Dart SDK floor to `^3.11.0`, since analyzer 13.1.0+ (the version pub resolves to in practice) requires it.