### PR TITLE
test(snapshot): apply snapshot tag at library level

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,5 +1,7 @@
 # https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md
 tags:
+  snapshot:
+    # Designates tests comparing against Node.js manifests generated via npm/npx.
   e2e:
     # Designates integration tests that require the Firebase Local Emulator Suite.
     # These tests spin up external processes (like Node.js and Java emulators)

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -36,12 +36,17 @@ void main() {
     setUpAll(() async {
       // Generate the basic example manifest
       print('Generating basic Dart manifest via build_runner...');
-      final buildResult = await Process.run(Platform.resolvedExecutable, [
+      const args = [
         'run',
         'build_runner',
         'build',
         '--delete-conflicting-outputs',
-      ], workingDirectory: 'test/fixtures/dart_reference');
+      ];
+      final buildResult = await Process.run(
+        Platform.resolvedExecutable,
+        args,
+        workingDirectory: 'test/fixtures/dart_reference',
+      );
 
       if (buildResult.exitCode != 0) {
         throw Exception(

--- a/test/snapshots/manifest_snapshot_test.dart
+++ b/test/snapshots/manifest_snapshot_test.dart
@@ -18,6 +18,7 @@
 ///
 /// This test ensures that the Dart builder generates manifests compatible
 /// with the Node.js Firebase Functions SDK.
+@Tags(['snapshot'])
 library;
 
 import 'dart:convert';
@@ -35,7 +36,7 @@ void main() {
     setUpAll(() async {
       // Generate the basic example manifest
       print('Generating basic Dart manifest via build_runner...');
-      final buildResult = await Process.run('dart', [
+      final buildResult = await Process.run(Platform.resolvedExecutable, [
         'run',
         'build_runner',
         'build',


### PR DESCRIPTION
Why this change is needed:
Function-level tag annotations do not prevent library loading or top-level
setUpAll hooks from executing when tags are excluded. On systems without
Node.js or manifests, setUpAll threw during unit test filtering.

Summary of changes:
* Apply @Tags(['snapshot']) at the library level above library directive.
* Use Platform.resolvedExecutable when invoking build_runner in setUpAll.
* Declare snapshot tag in workspace dart_test.yaml configuration.
