### PR TITLE
chore(release): prepare breaking release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0-wip
+## 0.7.0
 
 - **BREAKING:** Replace custom `HttpsError` implementation with
   `HttpResponseException` from `package:google_cloud_shelf`. Surfacing errors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ name: firebase_functions
 description: >-
   Cloud Functions for Dart with support for the Firebase Admin SDK,
   Cloud Storage and Firestore
-version: 0.7.0-wip
+version: 0.7.0
 repository: https://github.com/firebase/firebase-functions-dart
 
 environment:
@@ -63,3 +63,7 @@ dev_dependencies:
   mocktail: ^1.0.4
   test: ^1.29.0
   yaml: ^3.1.3
+
+false_secrets:
+  - /test/fixtures/dummy_service_account.json
+  - /test/fixtures/mock_credentials.dart


### PR DESCRIPTION
Why this change is needed:
Prepares breaking pre-1.0 release for firebase_functions by transitioning out
of WIP status following the migration to HttpResponseException and logger API
refactoring. Adds false_secrets to allow clean publishing to pub.dev.

Summary of changes:
* Remove -wip suffix from version in pubspec and changelog to stage 0.7.0.
* Add false_secrets configuration in pubspec.yaml for mock test credentials.
