### PR TITLE
fix(build): anchor .firebaserc ignore rule to package root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ yarn-error.log
 
 # Firebase
 .firebase/
-.firebaserc
+/.firebaserc
 firebase-debug.log
 firestore-debug.log
 ui-debug.log


### PR DESCRIPTION
Why this change is needed:
An unanchored .firebaserc gitignore pattern matches sample configuration files
checked into example subdirectories, which generates warnings during package
validation and fails non-interactive pub publishing.

Summary of changes:
* Anchor .firebaserc ignore rule to the repository root in .gitignore.
