### PR TITLE
Optimize json encoding, fix IdentityNamespace _validateAuthResponse

### DIFF
--- a/lib/src/common/utilities.dart
+++ b/lib/src/common/utilities.dart
@@ -30,3 +30,9 @@ Future<Map<String, dynamic>> readAsJsonMap(Request request) async {
 }
 
 final _converter = const Utf8Decoder().fuse(const JsonDecoder());
+
+final _encoder = JsonUtf8Encoder();
+
+List<int> encodeJsonBytes(Object? obj) {
+  return _encoder.convert(obj);
+}

--- a/lib/src/https/callable.dart
+++ b/lib/src/https/callable.dart
@@ -21,6 +21,7 @@ import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:shelf/shelf.dart';
 
 import '../../logger.dart' as logger;
+import '../common/utilities.dart';
 
 /// JSON decoder function type.
 typedef JsonDecoder<T extends Object?> = T Function(Map<String, dynamic>);
@@ -44,7 +45,7 @@ class CallableResult<T extends Object> {
 
   /// Converts this result to a Shelf Response.
   Response toResponse() => Response.ok(
-    jsonEncode({'result': data}),
+    encodeJsonBytes({'result': data}),
     headers: {HttpHeaders.contentTypeHeader: 'application/json'},
   );
 }
@@ -365,7 +366,7 @@ class CallableResponse<T extends Object> {
 
   /// Encodes data as SSE format.
   List<int> _encodeSSE(Map<String, dynamic> data) {
-    final jsonBytes = json.fuse(utf8).encode(data);
+    final jsonBytes = encodeJsonBytes(data);
     return (BytesBuilder(copy: false)
           ..add(_dataPrefix)
           ..add(jsonBytes)

--- a/lib/src/https/https_namespace.dart
+++ b/lib/src/https/https_namespace.dart
@@ -20,6 +20,7 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 
 import '../common/options.dart';
+import '../common/utilities.dart';
 import '../firebase.dart';
 import 'auth.dart';
 import 'callable.dart';
@@ -232,7 +233,7 @@ class HttpsNamespace extends FunctionsNamespace {
           handler,
           (result) => result,
           (result) => Response.ok(
-            jsonEncode({'result': result}),
+            encodeJsonBytes({'result': result}),
             headers: {'Content-Type': 'application/json'},
           ),
         );

--- a/lib/src/identity/identity_namespace.dart
+++ b/lib/src/identity/identity_namespace.dart
@@ -337,7 +337,7 @@ class IdentityNamespace extends FunctionsNamespace {
           throw HttpResponseException.badRequest(
             message:
                 'The customClaims payload should not exceed $claimsMaxPayloadSize '
-                'characters.',
+                'bytes.',
           );
         }
       }
@@ -360,7 +360,7 @@ class IdentityNamespace extends FunctionsNamespace {
           throw HttpResponseException.badRequest(
             message:
                 'The sessionClaims payload should not exceed $claimsMaxPayloadSize '
-                'characters.',
+                'bytes.',
           );
         }
 
@@ -371,7 +371,7 @@ class IdentityNamespace extends FunctionsNamespace {
           throw HttpResponseException.badRequest(
             message:
                 'The customClaims and sessionClaims payloads should not exceed '
-                '$claimsMaxPayloadSize characters combined.',
+                '$claimsMaxPayloadSize bytes combined.',
           );
         }
       }

--- a/lib/src/identity/identity_namespace.dart
+++ b/lib/src/identity/identity_namespace.dart
@@ -16,7 +16,6 @@
 library;
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:meta/meta.dart';
@@ -249,7 +248,7 @@ class IdentityNamespace extends FunctionsNamespace {
       final result = generateResponsePayload(response);
 
       return Response.ok(
-        jsonEncode(result.toJson()),
+        encodeJsonBytes(result.toJson()),
         headers: {'Content-Type': 'application/json'},
       );
     });
@@ -334,7 +333,7 @@ class IdentityNamespace extends FunctionsNamespace {
                 'and cannot be specified.',
           );
         }
-        if (jsonEncode(customClaims).length > claimsMaxPayloadSize) {
+        if (encodeJsonBytes(customClaims).length > claimsMaxPayloadSize) {
           throw HttpResponseException.badRequest(
             message:
                 'The customClaims payload should not exceed $claimsMaxPayloadSize '
@@ -357,7 +356,7 @@ class IdentityNamespace extends FunctionsNamespace {
                 'and cannot be specified.',
           );
         }
-        if (jsonEncode(sessionClaims).length > claimsMaxPayloadSize) {
+        if (encodeJsonBytes(sessionClaims).length > claimsMaxPayloadSize) {
           throw HttpResponseException.badRequest(
             message:
                 'The sessionClaims payload should not exceed $claimsMaxPayloadSize '
@@ -368,7 +367,7 @@ class IdentityNamespace extends FunctionsNamespace {
         // Check combined size
         final customClaims = authResponse.customClaims ?? {};
         final combinedClaims = {...customClaims, ...sessionClaims};
-        if (jsonEncode(combinedClaims).length > claimsMaxPayloadSize) {
+        if (encodeJsonBytes(combinedClaims).length > claimsMaxPayloadSize) {
           throw HttpResponseException.badRequest(
             message:
                 'The customClaims and sessionClaims payloads should not exceed '

--- a/lib/src/testing.dart
+++ b/lib/src/testing.dart
@@ -24,6 +24,7 @@ import 'package:shelf/shelf.dart';
 
 import 'common/cloud_run_id.dart';
 import 'common/environment.dart';
+import 'common/utilities.dart';
 import 'firebase.dart';
 // ignore: invalid_use_of_visible_for_testing_member
 import 'server.dart' show FunctionsRunner, createTestHandler;
@@ -114,7 +115,7 @@ class FunctionsTestClient {
     final request = Request(
       'POST',
       Uri.parse('http://localhost/${toCloudRunId(name)}'),
-      body: jsonEncode({'data': data}),
+      body: encodeJsonBytes({'data': data}),
       headers: headers,
     );
     return _invoke(toCloudRunId(name), request);

--- a/test/unit/identity_namespace_test.dart
+++ b/test/unit/identity_namespace_test.dart
@@ -85,6 +85,15 @@ void main() {
         return await func.handler(req);
       }
 
+      test('succeeds for valid response', () async {
+        identity.beforeUserCreated((ev) => const BeforeCreateResponse());
+
+        expect(
+          (await handle(createEvent())).readAsString().then(json.decode),
+          completes,
+        );
+      });
+
       test('fails for invalid custom claims size', () async {
         var i = 0;
         identity.beforeUserCreated((ev) {
@@ -106,10 +115,56 @@ void main() {
         return await func.handler(req);
       }
 
+      test('succeeds for valid response', () async {
+        identity.beforeUserSignedIn((ev) => const BeforeSignInResponse());
+
+        expect(
+          (await handle(createEvent())).readAsString().then(json.decode),
+          completes,
+        );
+      });
+
       test('fails for invalid custom claims size', () async {
         var i = 0;
         identity.beforeUserSignedIn((ev) {
           return BeforeSignInResponse(customClaims: tooLargeCustomClaims[i]);
+        });
+        for (final l = tooLargeCustomClaims.length; i < l; i++) {
+          await expectLater(
+            handle(createEvent()),
+            throwsA(isA<HttpResponseException>()),
+          );
+        }
+      });
+
+      test('fails for invalid session claims size', () async {
+        var i = 0;
+        identity.beforeUserSignedIn((ev) {
+          return BeforeSignInResponse(sessionClaims: tooLargeCustomClaims[i]);
+        });
+        for (final l = tooLargeCustomClaims.length; i < l; i++) {
+          await expectLater(
+            handle(createEvent()),
+            throwsA(isA<HttpResponseException>()),
+          );
+        }
+      });
+
+      test('fails for combined claims size', () async {
+        var i = 0;
+        identity.beforeUserSignedIn((ev) {
+          final custom = <String, String>{};
+          final session = <String, String>{};
+          tooLargeCustomClaims[i].forEach((key, value) {
+            final length = value.length ~/ 2;
+            custom[key] = value.substring(0, length);
+            session['$key-2'] = value.substring(length);
+          });
+
+          return BeforeSignInResponse(
+            customClaims: custom,
+            sessionClaims: session,
+          );
         });
         for (final l = tooLargeCustomClaims.length; i < l; i++) {
           await expectLater(

--- a/test/unit/identity_namespace_test.dart
+++ b/test/unit/identity_namespace_test.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+
+import 'package:firebase_functions/src/common/environment.dart';
+import 'package:firebase_functions/src/firebase.dart';
+import 'package:firebase_functions/src/identity/auth_blocking_event.dart';
+import 'package:firebase_functions/src/identity/identity_namespace.dart';
+import 'package:firebase_functions/src/identity/responses.dart';
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+
+// Helper to find function by name
+FirebaseFunctionDeclaration? _findFunction(Firebase firebase, String name) =>
+    firebase.functions.where((f) => f.name == name).singleOrNull;
+
+void main() {
+  setUpAll(() {
+    FirebaseEnv.mockEnvironment = {'FIREBASE_PROJECT': 'demo-test'};
+  });
+
+  group('IdentityNamespace', () {
+    const maxPayload = 1000;
+    const constant = '{"k":""}'.length;
+    const availablePayloadSize = maxPayload - constant;
+    String fillPayload(String pattern, {bool useUtf8 = false}) {
+      final patternSize = useUtf8
+          ? utf8.encode(pattern).length
+          : pattern.length;
+      final repetitions = (availablePayloadSize ~/ patternSize) + 1;
+      return pattern * repetitions;
+    }
+
+    final tooLargeCustomClaims = [
+      {'k': fillPayload('*')},
+      {'k': fillPayload('*', useUtf8: true)},
+      {'k': fillPayload('❤️')},
+      {'k': fillPayload('❤️', useUtf8: true)},
+    ];
+
+    late Firebase firebase;
+    late IdentityNamespace identity;
+
+    setUp(() {
+      firebase = createFirebaseInternal()
+        ..$env.environment['FUNCTIONS_EMULATOR'] = 'true';
+      identity = IdentityNamespace(firebase);
+    });
+
+    Request createRequest(String name, AuthBlockingEvent event) {
+      return Request(
+        'POST',
+        Uri.parse('http://localhost/$name'),
+        headers: {'content-type': 'application/json'},
+        body: json.encode({
+          'data': {'jwt': event.toJwt()},
+        }),
+      );
+    }
+
+    AuthBlockingEvent createEvent() {
+      return const AuthBlockingEvent(
+        ipAddress: '0.0.0.0',
+        userAgent: 'test-cli',
+      );
+    }
+
+    group('beforeUserCreated', () {
+      Future<Response> handle(AuthBlockingEvent event) async {
+        final func = _findFunction(firebase, 'beforecreate')!;
+        final req = createRequest('beforecreate', event);
+        return await func.handler(req);
+      }
+
+      test('fails for invalid custom claims size', () async {
+        var i = 0;
+        identity.beforeUserCreated((ev) {
+          return BeforeCreateResponse(customClaims: tooLargeCustomClaims[i]);
+        });
+        for (final l = tooLargeCustomClaims.length; i < l; i++) {
+          await expectLater(
+            handle(createEvent()),
+            throwsA(isA<HttpResponseException>()),
+          );
+        }
+      });
+    });
+
+    group('beforeUserSignedIn', () {
+      Future<Response> handle(AuthBlockingEvent event) async {
+        final func = _findFunction(firebase, 'beforesignin')!;
+        final req = createRequest('beforesignin', event);
+        return await func.handler(req);
+      }
+
+      test('fails for invalid custom claims size', () async {
+        var i = 0;
+        identity.beforeUserSignedIn((ev) {
+          return BeforeSignInResponse(customClaims: tooLargeCustomClaims[i]);
+        });
+        for (final l = tooLargeCustomClaims.length; i < l; i++) {
+          await expectLater(
+            handle(createEvent()),
+            throwsA(isA<HttpResponseException>()),
+          );
+        }
+      });
+    });
+  });
+}
+
+extension on AuthBlockingEvent {
+  String toJwt() {
+    final payload = json.encode(toJson());
+    final payloadBase64 = base64Url.encode(utf8.encode(payload));
+    final header = json.encode({'alg': 'none', 'typ': 'JWT'});
+    final headerBase64 = base64Url.encode(utf8.encode(header));
+    return '$headerBase64.$payloadBase64';
+  }
+}

--- a/test/unit/identity_namespace_test.dart
+++ b/test/unit/identity_namespace_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:convert';
 
 import 'package:firebase_functions/src/common/environment.dart';


### PR DESCRIPTION
Whenever we encoded responses to json, we always encoded them to strings and then to utf8 bytes.

This PR, adds a new helper `encodeJsonBytes` that uses the `JsonUtf8Encoder` to skip the intermediary encoding step.

- lib/ was updated to use the new helper
- test/ was skipped to avoid an unnecessary diff

Additionally, when updating the code, the current implementation of `_validateAuthResponse` in `IdentityNamespace` was incorrectly computing max payload size. It serialised a json object to a string, and checked the length of a string. The payload max size is 1000 bytes. This means if custom claims contain complex characters like emojis. The final utf8 encoding will be greater.

Since Identity tests didn't exist jett, I added a compact test file, following the pattern in Https tests.
I only added tested for this change. With test cases that succeed with the current implementation and fail in the previous one.