### PR TITLE
feat: expose checkTokens() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Expose `checkTokens`, `extractAuthToken`, `extractAppCheckToken`,
+  `TokenStatus`, and `TokenVerificationResult` from
+  `package:firebase_functions/firebase_functions.dart`, so `onRequest`
+  handlers can verify Firebase Auth ID tokens and App Check tokens without
+  reimplementing header parsing (#235).
+
 ## 0.7.0
 
 - **BREAKING:** Replace custom `HttpsError` implementation with

--- a/example/https/bin/server.dart
+++ b/example/https/bin/server.dart
@@ -147,6 +147,21 @@ void main(List<String> args) async {
       },
     );
 
+    // HTTPS onRequest example - verifying Auth/App Check tokens manually via
+    // checkTokens, the same verification onCall/onCallWithData run internally.
+    firebase.https.onRequest(name: 'whoAmI', (request) async {
+      final tokens = await checkTokens(
+        request.headers,
+        adminApp: firebase.adminApp,
+      );
+
+      if (tokens.result.auth != TokenStatus.valid) {
+        return Response.forbidden('Missing or invalid ID token');
+      }
+
+      return Response.ok('Hello, ${tokens.authData!.uid}!');
+    });
+
     // Conditional configuration based on boolean parameter
     firebase.https.onRequest(
       name: 'configuredEndpoint',

--- a/example/https/bin/server.dart
+++ b/example/https/bin/server.dart
@@ -155,11 +155,12 @@ void main(List<String> args) async {
         adminApp: firebase.adminApp,
       );
 
-      if (tokens.result.auth != TokenStatus.valid) {
+      final authData = tokens.authData;
+      if (tokens.result.auth != TokenStatus.valid || authData == null) {
         return Response.forbidden('Missing or invalid ID token');
       }
 
-      return Response.ok('Hello, ${tokens.authData!.uid}!');
+      return Response.ok('Hello, ${authData.uid}!');
     });
 
     // Conditional configuration based on boolean parameter

--- a/lib/src/https/auth.dart
+++ b/lib/src/https/auth.dart
@@ -194,10 +194,11 @@ Future<(TokenStatus, AppCheckData?)> extractAppCheckToken(
 ///       request.headers,
 ///       adminApp: firebase.adminApp,
 ///     );
-///     if (tokens.result.auth != TokenStatus.valid) {
+///     final authData = tokens.authData;
+///     if (tokens.result.auth != TokenStatus.valid || authData == null) {
 ///       return Response.forbidden('Unauthorized');
 ///     }
-///     return Response.ok('Hello, ${tokens.authData!.uid}!');
+///     return Response.ok('Hello, ${authData.uid}!');
 ///   },
 /// );
 /// ```

--- a/lib/src/https/auth.dart
+++ b/lib/src/https/auth.dart
@@ -39,7 +39,10 @@ enum TokenStatus {
 class TokenVerificationResult {
   const TokenVerificationResult({required this.auth, required this.app});
 
+  /// Status of the Firebase Auth ID token.
   final TokenStatus auth;
+
+  /// Status of the App Check token.
   final TokenStatus app;
 }
 
@@ -173,7 +176,31 @@ Future<(TokenStatus, AppCheckData?)> extractAppCheckToken(
 
 /// Checks both auth and app check tokens on a request.
 ///
+/// This is the same verification `onCall`/`onCallWithData` run internally;
+/// use it directly inside an `onRequest` handler to get Auth and App Check
+/// verification without reimplementing header parsing.
+///
+/// Pass `adminApp: null` to skip verification and decode tokens unchecked
+/// (emulator mode).
+///
 /// Returns a record containing the verification result and extracted data.
+///
+/// Example:
+/// ```dart
+/// firebase.https.onRequest(
+///   name: 'secureEndpoint',
+///   (request) async {
+///     final tokens = await checkTokens(
+///       request.headers,
+///       adminApp: firebase.adminApp,
+///     );
+///     if (tokens.result.auth != TokenStatus.valid) {
+///       return Response.forbidden('Unauthorized');
+///     }
+///     return Response.ok('Hello, ${tokens.authData!.uid}!');
+///   },
+/// );
+/// ```
 Future<
   ({
     TokenVerificationResult result,

--- a/lib/src/https/https.dart
+++ b/lib/src/https/https.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export 'auth.dart';
 export 'callable.dart';
 export 'https_namespace.dart';
 export 'options.dart';

--- a/test/unit/https_auth_test.dart
+++ b/test/unit/https_auth_test.dart
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert';
-
 import 'package:firebase_functions/src/https/auth.dart';
 import 'package:firebase_functions/src/https/callable.dart';
 import 'package:test/test.dart';
+
+import 'shared_utils.dart';
 
 void main() {
   // All tests use skipTokenVerification: true since we can't easily mock
@@ -44,7 +44,7 @@ void main() {
     );
 
     test('returns invalid when token has no uid/sub claim', () async {
-      final jwt = _createJwt({'email': 'test@example.com'});
+      final jwt = createJwt({'email': 'test@example.com'});
 
       final (status, auth) = await extractAuthToken({
         'authorization': 'Bearer $jwt',
@@ -55,7 +55,7 @@ void main() {
     });
 
     test('returns valid with AuthData for valid token', () async {
-      final jwt = _createJwt({
+      final jwt = createJwt({
         'sub': 'user123',
         'email': 'test@example.com',
         'custom_claim': 'value',
@@ -74,7 +74,7 @@ void main() {
     });
 
     test('extracts uid from user_id claim as fallback', () async {
-      final jwt = _createJwt({'user_id': 'user456'});
+      final jwt = createJwt({'user_id': 'user456'});
 
       final (status, auth) = await extractAuthToken({
         'authorization': 'Bearer $jwt',
@@ -85,7 +85,7 @@ void main() {
     });
 
     test('handles case-insensitive Bearer prefix', () async {
-      final jwt = _createJwt({'sub': 'user123'});
+      final jwt = createJwt({'sub': 'user123'});
 
       final (status, auth) = await extractAuthToken({
         'authorization': 'bearer $jwt',
@@ -105,7 +105,7 @@ void main() {
     });
 
     test('returns invalid for JWT with empty payload', () async {
-      final jwt = _createJwt({});
+      final jwt = createJwt({});
 
       final (status, auth) = await extractAuthToken({
         'authorization': 'Bearer $jwt',
@@ -125,7 +125,7 @@ void main() {
     });
 
     test('returns invalid when token has no sub claim', () async {
-      final jwt = _createJwt({'other': 'value'});
+      final jwt = createJwt({'other': 'value'});
 
       final (status, appCheck) = await extractAppCheckToken({
         'x-firebase-appcheck': jwt,
@@ -136,7 +136,7 @@ void main() {
     });
 
     test('returns valid with AppCheckData for valid token', () async {
-      final jwt = _createJwt({'sub': 'app123'});
+      final jwt = createJwt({'sub': 'app123'});
 
       final (status, appCheck) = await extractAppCheckToken({
         'x-firebase-appcheck': jwt,
@@ -149,7 +149,7 @@ void main() {
     });
 
     test('extracts app_id from explicit claim', () async {
-      final jwt = _createJwt({'sub': 'sub-value', 'app_id': 'explicit-app-id'});
+      final jwt = createJwt({'sub': 'sub-value', 'app_id': 'explicit-app-id'});
 
       final (status, appCheck) = await extractAppCheckToken({
         'x-firebase-appcheck': jwt,
@@ -162,8 +162,8 @@ void main() {
 
   group('checkTokens', () {
     test('returns both auth and app check data when present', () async {
-      final authJwt = _createJwt({'sub': 'user123'});
-      final appCheckJwt = _createJwt({'sub': 'app123'});
+      final authJwt = createJwt({'sub': 'user123'});
+      final appCheckJwt = createJwt({'sub': 'app123'});
 
       final result = await checkTokens({
         'authorization': 'Bearer $authJwt',
@@ -186,8 +186,8 @@ void main() {
     });
 
     test('handles mixed valid and invalid tokens', () async {
-      final authJwt = _createJwt({'sub': 'user123'});
-      final invalidAppCheckJwt = _createJwt({'no_sub': 'value'});
+      final authJwt = createJwt({'sub': 'user123'});
+      final invalidAppCheckJwt = createJwt({'no_sub': 'value'});
 
       final result = await checkTokens({
         'authorization': 'Bearer $authJwt',
@@ -241,20 +241,4 @@ void main() {
       expect(result.app, TokenStatus.missing);
     });
   });
-}
-
-/// Creates a minimal JWT token for testing.
-///
-/// This creates a token with a dummy header and signature, but a real
-/// base64-encoded payload. This is only for testing the decode functions
-/// in emulator mode where verification is skipped.
-String _createJwt(Map<String, dynamic> payload) {
-  final headerJson = jsonEncode({'alg': 'HS256', 'typ': 'JWT'});
-  final payloadJson = jsonEncode(payload);
-
-  final header = base64Url.encode(utf8.encode(headerJson)).replaceAll('=', '');
-  final body = base64Url.encode(utf8.encode(payloadJson)).replaceAll('=', '');
-  const signature = 'dummysignature';
-
-  return '$header.$body.$signature';
 }

--- a/test/unit/https_public_api_test.dart
+++ b/test/unit/https_public_api_test.dart
@@ -12,22 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Regression test for https://github.com/invertase/firebase-functions-dart/issues/235:
-// `checkTokens`/`extractAuthToken`/`extractAppCheckToken` and their supporting
-// types must be reachable from the public package barrel so `onRequest`
-// handlers can verify tokens without reaching into `src/`.
-import 'dart:convert';
-
 import 'package:firebase_functions/firebase_functions.dart';
 import 'package:test/test.dart';
+
+import 'shared_utils.dart';
 
 void main() {
   test(
     'checkTokens, extractAuthToken, extractAppCheckToken, TokenStatus and '
     'TokenVerificationResult are importable from the public barrel',
     () async {
-      final authJwt = _createJwt({'sub': 'user123'});
-      final appCheckJwt = _createJwt({'sub': 'app123'});
+      final authJwt = createJwt({'sub': 'user123'});
+      final appCheckJwt = createJwt({'sub': 'app123'});
 
       final (authStatus, authData) = await extractAuthToken({
         'authorization': 'Bearer $authJwt',
@@ -55,16 +51,4 @@ void main() {
       expect(tokens.appCheckData?.appId, 'app123');
     },
   );
-}
-
-/// Creates a minimal JWT for testing (unverified/emulator-mode decode path).
-String _createJwt(Map<String, dynamic> payload) {
-  final headerJson = jsonEncode({'alg': 'HS256', 'typ': 'JWT'});
-  final payloadJson = jsonEncode(payload);
-
-  final header = base64Url.encode(utf8.encode(headerJson)).replaceAll('=', '');
-  final body = base64Url.encode(utf8.encode(payloadJson)).replaceAll('=', '');
-  const signature = 'dummysignature';
-
-  return '$header.$body.$signature';
 }

--- a/test/unit/https_public_api_test.dart
+++ b/test/unit/https_public_api_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for https://github.com/invertase/firebase-functions-dart/issues/235:
+// `checkTokens`/`extractAuthToken`/`extractAppCheckToken` and their supporting
+// types must be reachable from the public package barrel so `onRequest`
+// handlers can verify tokens without reaching into `src/`.
+import 'dart:convert';
+
+import 'package:firebase_functions/firebase_functions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'checkTokens, extractAuthToken, extractAppCheckToken, TokenStatus and '
+    'TokenVerificationResult are importable from the public barrel',
+    () async {
+      final authJwt = _createJwt({'sub': 'user123'});
+      final appCheckJwt = _createJwt({'sub': 'app123'});
+
+      final (authStatus, authData) = await extractAuthToken({
+        'authorization': 'Bearer $authJwt',
+      });
+      expect(authStatus, TokenStatus.valid);
+      expect(authData?.uid, 'user123');
+
+      final (appStatus, appCheckData) = await extractAppCheckToken({
+        'x-firebase-appcheck': appCheckJwt,
+      });
+      expect(appStatus, TokenStatus.valid);
+      expect(appCheckData?.appId, 'app123');
+
+      final tokens = await checkTokens({
+        'authorization': 'Bearer $authJwt',
+        'x-firebase-appcheck': appCheckJwt,
+      });
+      expect(
+        tokens.result,
+        isA<TokenVerificationResult>()
+            .having((r) => r.auth, 'auth', TokenStatus.valid)
+            .having((r) => r.app, 'app', TokenStatus.valid),
+      );
+      expect(tokens.authData?.uid, 'user123');
+      expect(tokens.appCheckData?.appId, 'app123');
+    },
+  );
+}
+
+/// Creates a minimal JWT for testing (unverified/emulator-mode decode path).
+String _createJwt(Map<String, dynamic> payload) {
+  final headerJson = jsonEncode({'alg': 'HS256', 'typ': 'JWT'});
+  final payloadJson = jsonEncode(payload);
+
+  final header = base64Url.encode(utf8.encode(headerJson)).replaceAll('=', '');
+  final body = base64Url.encode(utf8.encode(payloadJson)).replaceAll('=', '');
+  const signature = 'dummysignature';
+
+  return '$header.$body.$signature';
+}

--- a/test/unit/shared_utils.dart
+++ b/test/unit/shared_utils.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:firebase_functions/src/firebase.dart';
 import 'package:firebase_functions/src/server.dart';
 import 'package:shelf/shelf.dart';
@@ -35,4 +37,20 @@ Handler findHandler(Firebase firebase, String name) {
       ),
     );
   };
+}
+
+/// Creates a minimal JWT token for testing.
+///
+/// This creates a token with a dummy header and signature, but a real
+/// base64-encoded payload. This is only for testing the decode functions
+/// in emulator mode where verification is skipped.
+String createJwt(Map<String, dynamic> payload) {
+  final headerJson = jsonEncode({'alg': 'HS256', 'typ': 'JWT'});
+  final payloadJson = jsonEncode(payload);
+
+  final header = base64Url.encode(utf8.encode(headerJson)).replaceAll('=', '');
+  final body = base64Url.encode(utf8.encode(payloadJson)).replaceAll('=', '');
+  const signature = 'dummysignature';
+
+  return '$header.$body.$signature';
 }


### PR DESCRIPTION
Closes #235.

`onCall` and `onCallWithData` get Auth ID token and App Check verification for free via an internal `checkTokens` helper, but `onRequest` had no equivalent — anyone wanting the same guarantees while using a custom request shape (e.g. a binary protocol instead of `onCall`'s base64-heavy wire format) had to reimplement header parsing and token verification from scratch.

Exposes `checkTokens`, `extractAuthToken`, `extractAppCheckToken`, `TokenStatus`, and `TokenVerificationResult` from the public package barrel (they already existed in `lib/src/https/auth.dart`, just weren't reachable outside the package). Adds a `whoAmI` example in `example/https` showing `checkTokens` used directly inside an `onRequest` handler, plus a test locking in that these symbols stay importable from `package:firebase_functions/firebase_functions.dart`.