### PR TITLE
ci: add Flutter workspace compatibility check

### DIFF
--- a/.github/workflows/flutter-compat.yml
+++ b/.github/workflows/flutter-compat.yml
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Flutter Compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Checks that firebase_functions can still be resolved inside a pub
+  # workspace alongside a Flutter app on current Flutter stable.
+  # `continue-on-error` is set because this is currently expected to fail:
+  # see https://github.com/firebase/firebase-functions-dart/issues/236
+  # (google_cloud_shelf/google_cloud_logging pin meta ^1.18.2, which is
+  # newer than what Flutter stable bundles). Remove it once that's resolved
+  # upstream so this becomes a blocking regression check.
+  flutter-workspace-compat:
+    name: Flutter Workspace Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        with:
+          persist-credentials: false
+
+      - name: Setup Flutter SDK
+        run: |
+          git clone https://github.com/flutter/flutter.git -b stable --depth 1 "$HOME/flutter"
+          echo "$HOME/flutter/bin" >> "$GITHUB_PATH"
+
+      - name: Print Flutter version
+        run: flutter --version
+
+      - name: Resolve dependencies in Flutter + firebase_functions workspace
+        working-directory: example/flutter_test
+        run: flutter pub get

--- a/.github/workflows/flutter-compat.yml
+++ b/.github/workflows/flutter-compat.yml
@@ -31,18 +31,10 @@ permissions:
   contents: read
 
 jobs:
-  # Checks that firebase_functions can still be resolved inside a pub
-  # workspace alongside a Flutter app on current Flutter stable.
-  # `continue-on-error` is set because this is currently expected to fail:
-  # see https://github.com/firebase/firebase-functions-dart/issues/236
-  # (google_cloud_shelf/google_cloud_logging pin meta ^1.18.2, which is
-  # newer than what Flutter stable bundles). Remove it once that's resolved
-  # upstream so this becomes a blocking regression check.
   flutter-workspace-compat:
     name: Flutter Workspace Compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,30 +108,6 @@ jobs:
       - name: Run unit tests
         run: dart test --exclude-tags=snapshot,integration,e2e
 
-  flutter-workspace-compat:
-    name: Flutter Workspace Compatibility
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    continue-on-error: true
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
-        with:
-          persist-credentials: false
-
-      - name: Setup Flutter SDK
-        run: |
-          git clone https://github.com/flutter/flutter.git -b stable --depth 1 "$HOME/flutter"
-          echo "$HOME/flutter/bin" >> "$GITHUB_PATH"
-
-      - name: Print Flutter version
-        run: flutter --version
-
-      - name: Resolve dependencies in Flutter + firebase_functions workspace
-        working-directory: example/flutter_test
-        run: flutter pub get
-
   # Builder tests - generate and display functions.yaml
   builder-tests:
     name: Builder Tests
@@ -310,7 +286,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [check-license-header, lint-analyze, flutter-workspace-compat, builder-tests, snapshot-tests, e2e-tests]
+    needs: [check-license-header, lint-analyze, builder-tests, snapshot-tests, e2e-tests]
     if: always()
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Analyze all packages
         run: |
           dart analyze --fatal-infos
-          find example -type f -name pubspec.yaml -not -path '*/.*' -exec dirname {} \; | while read -r dir; do
+          find example -type f -name pubspec.yaml -not -path '*/.*' -not -path '*/flutter_test/*' -exec dirname {} \; | while read -r dir; do
             echo "Analyzing $dir..."
             dart analyze --fatal-infos "$dir"
           done
@@ -107,6 +107,30 @@ jobs:
 
       - name: Run unit tests
         run: dart test --exclude-tags=snapshot,integration,e2e
+
+  flutter-workspace-compat:
+    name: Flutter Workspace Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        with:
+          persist-credentials: false
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          channel: stable
+
+      - name: Print Flutter version
+        run: flutter --version
+
+      - name: Resolve dependencies in Flutter + firebase_functions workspace
+        working-directory: example/flutter_test
+        run: flutter pub get
 
   # Builder tests - generate and display functions.yaml
   builder-tests:
@@ -286,7 +310,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [check-license-header, lint-analyze, builder-tests, snapshot-tests, e2e-tests]
+    needs: [check-license-header, lint-analyze, flutter-workspace-compat, builder-tests, snapshot-tests, e2e-tests]
     if: always()
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,9 +121,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: stable
+        run: |
+          git clone https://github.com/flutter/flutter.git -b stable --depth 1 "$HOME/flutter"
+          echo "$HOME/flutter/bin" >> "$GITHUB_PATH"
 
       - name: Print Flutter version
         run: flutter --version

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,6 +15,10 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
+  exclude:
+    # Requires the Flutter SDK, which isn't available to the plain-Dart
+    # analyzer; see the Flutter Workspace Compatibility CI job instead.
+    - example/flutter_test/**
   language:
     strict-casts: true
     strict-inference: true

--- a/example/flutter_test/README.md
+++ b/example/flutter_test/README.md
@@ -1,0 +1,53 @@
+# Flutter + firebase_functions workspace conflict (issue #236)
+
+Reproduces [#236](https://github.com/firebase/firebase-functions-dart/issues/236):
+a [pub workspace](https://dart.dev/tools/pub/workspaces) that mixes a Flutter
+app with `firebase_functions` (e.g. to share models between a Flutter client
+and its Dart Cloud Functions backend, as in the
+[Dart Cloud Functions codelab](https://codelabs.developers.google.com/deploy-dart-on-firebase-functions))
+fails to resolve on Flutter stable.
+
+## Why
+
+- `flutter_app` depends on `flutter` from the SDK, which pins `meta` to
+  whatever exact version ships with the installed Flutter release.
+- `functions` depends on `firebase_functions`, which transitively requires
+  `google_cloud_shelf` and `google_cloud_logging` — both of which require
+  `meta: ^1.18.2`.
+- A pub workspace resolves a single `pubspec.lock` shared across all members,
+  so both constraints must be satisfiable at once. Flutter stable currently
+  bundles `meta 1.18.0`, so resolution fails.
+
+This is not fixable from `firebase_functions`' own `pubspec.yaml` — the tight
+`meta` lower bound lives in `google_cloud_shelf`/`google_cloud_logging`
+(part of [googleapis/google-cloud-dart](https://github.com/googleapis/google-cloud-dart)).
+
+## Reproducing
+
+This directory is intentionally **not** part of the root repo's pub
+workspace, and is excluded from CI's plain-Dart analyze sweep (see
+`.github/workflows/test.yml`), since exercising it requires the Flutter SDK.
+To see the failure locally:
+
+```bash
+cd example/flutter_test
+flutter pub get
+```
+
+Expected output:
+
+```
+Resolving dependencies...
+Note: meta is pinned to version 1.18.0 by flutter from the flutter SDK.
+See https://dart.dev/go/sdk-version-pinning for details.
+
+Because functions depends on firebase_functions ^0.7.0 which depends on
+google_cloud_shelf ^0.6.0, google_cloud_shelf ^0.6.0 is required.
+And because every version of google_cloud_shelf depends on meta ^1.18.2, meta
+^1.18.2 is required.
+So, because flutter_app depends on flutter from sdk which depends on meta
+1.18.0, version solving failed.
+Failed to update packages.
+```
+
+(Verified against Flutter 3.44.2 stable / Dart 3.12.2.)

--- a/example/flutter_test/flutter_app/lib/main.dart
+++ b/example/flutter_test/flutter_app/lib/main.dart
@@ -1,0 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MaterialApp(home: Scaffold()));
+}

--- a/example/flutter_test/flutter_app/pubspec.yaml
+++ b/example/flutter_test/flutter_app/pubspec.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: flutter_app
+description: >-
+  Stand-in for a Flutter client that shares code with the `functions`
+  package below in the same pub workspace. Its only job here is to pull in
+  `flutter` from the SDK, which pins `meta` to whatever exact version ships
+  with the installed Flutter stable release.
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.9.0
+
+dependencies:
+  flutter:
+    sdk: flutter

--- a/example/flutter_test/functions/bin/server.dart
+++ b/example/flutter_test/functions/bin/server.dart
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:firebase_functions/firebase_functions.dart';
+
+void main() async {
+  await runFunctions((firebase) {
+    firebase.https.onRequest(
+      name: 'helloWorld',
+      options: const HttpsOptions(invoker: Invoker.public()),
+      (request) async => Response.ok('Hello from Dart Functions!'),
+    );
+  });
+}

--- a/example/flutter_test/functions/pubspec.yaml
+++ b/example/flutter_test/functions/pubspec.yaml
@@ -25,4 +25,5 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  firebase_functions: ^0.7.0
+  firebase_functions:
+    path: ../../..

--- a/example/flutter_test/functions/pubspec.yaml
+++ b/example/flutter_test/functions/pubspec.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: functions
+description: >-
+  Stand-in for a Dart Cloud Functions backend sharing code with the Flutter
+  app above, in the same pub workspace. Depends on firebase_functions, which
+  transitively requires google_cloud_shelf/google_cloud_logging (meta
+  ^1.18.2).
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.9.0
+
+dependencies:
+  firebase_functions: ^0.7.0

--- a/example/flutter_test/pubspec.yaml
+++ b/example/flutter_test/pubspec.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: flutter_workspace_conflict
+publish_to: none
+
+environment:
+  sdk: ^3.9.0
+
+workspace:
+  - flutter_app
+  - functions


### PR DESCRIPTION
Closes #236.

`google_cloud_shelf` and `google_cloud_logging` pin `meta: ^1.18.2`, which is newer than what Flutter stable currently bundles (`1.18.0`). 

Added a Flutter-dependent example (`example/flutter_test`) plus a CI job that installs Flutter stable and runs `flutter pub get` against it, so this class of regression gets caught going forward.