### PR TITLE
fix: include custom claims in AuthData.token for verified tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Fix `extractAuthToken` dropping custom claims from `AuthData.token` for
+  verified (non-emulator) ID tokens; custom claims set via
+  `auth.setCustomUserClaims()` are now included alongside the standard claims.
+
 ## 0.7.0
 
 - **BREAKING:** Replace custom `HttpsError` implementation with

--- a/lib/src/https/auth.dart
+++ b/lib/src/https/auth.dart
@@ -96,6 +96,7 @@ Future<(TokenStatus, AuthData?)> extractAuthToken(
       final decoded = await auth.verifyIdToken(idToken);
       uid = decoded.uid;
       decodedToken = {
+        ...decoded.claims,
         'uid': decoded.uid,
         'sub': decoded.sub,
         'aud': decoded.aud,

--- a/test/unit/https_token_test.dart
+++ b/test/unit/https_token_test.dart
@@ -63,6 +63,20 @@ void main() {
       expect(authData.token?['sub'], 'user-abc');
     });
 
+    test('extracts custom claims from verified token', () async {
+      final token = mintIdToken(
+        uid: 'user-claims',
+        extraClaims: {'role': 'admin'},
+      );
+
+      final (status, authData) = await extractAuthToken({
+        'authorization': 'Bearer $token',
+      }, auth: auth);
+
+      expect(status, TokenStatus.valid);
+      expect(authData!.token?['role'], 'admin');
+    });
+
     test('rejects an expired token', () async {
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final token = mintIdToken(exp: now - 3600, iat: now - 7200);


### PR DESCRIPTION
Closes #239.

`extractAuthToken` verified the ID token via `Auth.verifyIdToken()`, but only copied a fixed set of standard fields into `AuthData.token`, silently dropping custom claims set via `auth.setCustomUserClaims()` even though the SDK had already decoded them onto `DecodedIdToken.claims`.

The fix spreads `decoded.claims` into that map, matching how the Node.js SDK forwards the full decoded token.